### PR TITLE
fix: PHP >= 8.0 compatibility for XMLWriter

### DIFF
--- a/Model/Write/XMLWriter.php
+++ b/Model/Write/XMLWriter.php
@@ -36,7 +36,7 @@ class XMLWriter extends BaseXMLWriter
         if ($value) {
             $value = $this->xmlPrepare($value);
         }
-        $this->text($value);
+        $this->text((string) $value);
 
         if (!is_numeric($value) && !empty($value)) {
             $this->endCdata();


### PR DESCRIPTION
PHP >= 8.0 requires a string (strict type) for XMLWriter::text(...)