### PR TITLE
Return exit instead of response

### DIFF
--- a/Controller/Feed/Export.php
+++ b/Controller/Feed/Export.php
@@ -100,7 +100,6 @@ class Export implements ActionInterface
 
         (new FeedContent($this->export, $this->log, $store, $request->getParam('type')))->__toString();
 
-        return $this->responseFactory->create()
-            ->setHeader('Cache-Control', 'no-cache');
+        exit();
     }
 }

--- a/Model/Export.php
+++ b/Model/Export.php
@@ -152,6 +152,7 @@ class Export
             }
 
             header('Content-type: text/xml');
+            header('Cache-Control: no-cache');
 
             while (!feof($sourceHandle)) {
                 fwrite($targetHandle, fread($sourceHandle, self::FEED_COPY_BUFFER_SIZE));

--- a/Model/Write/Products/CollectionDecorator/StockData/SourceItemMapProvider.php
+++ b/Model/Write/Products/CollectionDecorator/StockData/SourceItemMapProvider.php
@@ -236,6 +236,13 @@ class SourceItemMapProvider implements StockMapProviderInterface
         $stockId = $this->getStockIdForStoreId($store);
         $sourceModels = $this->getStockSourceProvider()->execute($stockId);
 
+        //don't get stock for disabled stock sources
+        foreach($sourceModels as $key => $sourceModel) {
+            if (!$sourceModel->isEnabled()) {
+                unset($sourceModels[$key]);
+            }
+        }
+
         $sourceCodeMapper = static function (SourceInterface $source) {
             return $source->getSourceCode();
         };

--- a/Model/Write/Products/CollectionDecorator/StockData/SourceItemMapProvider.php
+++ b/Model/Write/Products/CollectionDecorator/StockData/SourceItemMapProvider.php
@@ -236,13 +236,6 @@ class SourceItemMapProvider implements StockMapProviderInterface
         $stockId = $this->getStockIdForStoreId($store);
         $sourceModels = $this->getStockSourceProvider()->execute($stockId);
 
-        //don't get stock for disabled stock sources
-        foreach($sourceModels as $key => $sourceModel) {
-            if (!$sourceModel->isEnabled()) {
-                unset($sourceModels[$key]);
-            }
-        }
-
         $sourceCodeMapper = static function (SourceInterface $source) {
             return $source->getSourceCode();
         };


### PR DESCRIPTION
This is an fix for an headers already send error when reading the feed. Some external modules (weltpixel) set cookies to soon/late on tweakwise pages which results in an headers already send error. To prevent this, instead of an response we return an exit after returning the content.

This isn't an good solution for this, but the only one that works in every occasion and doesn't change the streaming of the feed content to the browser.