### PR TITLE
Removed unused array_flip

### DIFF
--- a/Model/Write/EavIterator.php
+++ b/Model/Write/EavIterator.php
@@ -301,7 +301,6 @@ class EavIterator implements IteratorAggregate
             $result = $select->query()->fetchAll();
             $entityIds = array_column($result, 'entity_id');
             $this->entitySet[$storeId] = new \ArrayIterator(array_chunk($entityIds, $this->batchSize));
-            array_flip($entityIds);
             $this->entityData = array_combine($entityIds, $result);
         }
 


### PR DESCRIPTION
array_flip returns the flipped array, it's not a function that takes a pointer, so this statement does nothing at this moment.