### PR TITLE
fix: trigger tweakwise import

### DIFF
--- a/Model/Export.php
+++ b/Model/Export.php
@@ -16,7 +16,7 @@ use Exception;
 use Magento\Framework\Profiler;
 use Magento\Store\Api\Data\StoreInterface;
 use Magento\Store\Model\StoreManagerInterface;
-use Zend\Http\Client as HttpClient;
+use \Magento\Framework\HTTP\LaminasClient as HttpClient;
 
 /**
  * Class Export
@@ -240,7 +240,7 @@ class Export
             $client = new HttpClient($apiImportUrl);
             $client->send();
             $this->log->debug('TW import triggered');
-        } catch (HttpClient\Exception\ExceptionInterface $e) {
+        } catch (Exception $e) {
             $this->log->error(sprintf('Trigger TW import failed due to %s', $e->getMessage()));
         }
     }

--- a/Model/Export.php
+++ b/Model/Export.php
@@ -16,7 +16,7 @@ use Exception;
 use Magento\Framework\Profiler;
 use Magento\Store\Api\Data\StoreInterface;
 use Magento\Store\Model\StoreManagerInterface;
-use \Magento\Framework\HTTP\LaminasClient as HttpClient;
+use Laminas\Http\Client as HttpClient;
 
 /**
  * Class Export

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": ">=8.0 <8.3"
+        "php": ">=8.0 <8.3",
+        "laminas/laminas-http": "^2.15.0"
     },
     "require-dev": {
         "fzaninotto/faker": "^1.7"


### PR DESCRIPTION
Class Zend_Http_Client is removed from Magento 2.4.6 and was used for the triggerTweakwiseImport function. 
We replaced the zend client for the LaminasClient to fix this issue.