### PR TITLE
Merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+# [7.0.0-beta.3](https://github.com/EmicoEcommerce/Magento2TweakwiseExport/compare/v7.0.0-beta.2...v7.0.0-beta.3) (2024-04-10)
+
+
+### Bug Fixes
+
+* use id instead of sku [#39](https://github.com/EmicoEcommerce/Magento2TweakwiseExport/issues/39) ([7f8fa8a](https://github.com/EmicoEcommerce/Magento2TweakwiseExport/commit/7f8fa8ab19cb024d280210d168713a61be0da2e9))
+
+
+### Performance Improvements
+
+* Applied phpcs and phpmd rules ([dad3813](https://github.com/EmicoEcommerce/Magento2TweakwiseExport/commit/dad3813f743f615d5459c5eb78be3f5109044efa))
+
+
+### BREAKING CHANGES
+
+* Code is refactored based on phpcs and phpmd rules. #37 #36
+
 # [7.0.0-beta.2](https://github.com/EmicoEcommerce/Magento2TweakwiseExport/compare/v7.0.0-beta.1...v7.0.0-beta.2) (2024-04-09)
 
 

--- a/README.md
+++ b/README.md
@@ -7,13 +7,7 @@ Install package using composer
 composer require tweakwise/magento2-tweakwise-export
 ```
 
-
 Enable module
-
-If 'Store Level Export' enabled single store feed  can be generated using the command line.
-```sh
-php bin/magento tweakwise:export --store '<storecode>'
-```
 
 Run installers
 ```sh
@@ -31,6 +25,11 @@ php bin/magento tweakwise:export
 php bin/magento tweakwise:export -t stock //stock export
 php bin/magento tweakwise:export -t price //price export
 php bin/magento tweakwise:export -s storecode //store level export, only works is store level export is enabled
+```
+
+If 'Store Level Export' enabled single store feed  can be generated using the command line.
+```sh
+php bin/magento tweakwise:export --store '<storecode>'
 ```
 
 ## Debugging


### PR DESCRIPTION
* chore: Added semantic release (#30)

* chore: Added semantic release

* chore: Added develop branch to semantic release

* chore: Set beta branch as prerelease branch

* chore: Only trigger release workflow for master and beta branch

* chore: Updated README for semantic release

* chore: Added Youwe Testing Suite

* chore: Added Magento secrets in testing suite action

* chore: Disabled phpstan linter

* chore: Fixed phpmd linter

* chore: Run grumphp directly with PHP

* fix: use id instead of SKU (#39)

Use entity_id in the WHERE clause instead of sku. This adjustment enhances the query's speed, especially when dealing with a large number of products.

During local testing, the export time decreased significantly from 50 minutes to just 8 minutes. Resulting in an increase in speed of 84%. This speed increase only seems to occur if you don't have all numbers as sku's.

* chore(release): 6.0.3-beta.1 [skip ci]

## [6.0.3-beta.1](https://github.com/EmicoEcommerce/Magento2TweakwiseExport/compare/v6.0.2...v6.0.3-beta.1) (2024-03-29)

### Bug Fixes

* use id instead of SKU ([#39](https://github.com/EmicoEcommerce/Magento2TweakwiseExport/issues/39)) ([7b325cb](https://github.com/EmicoEcommerce/Magento2TweakwiseExport/commit/7b325cba4e7b4f2c6de1227b64dac09e73a6cb6c))

* perf: Applied phpcs and phpmd rules

BREAKING CHANGE: Code is refactored based on phpcs and phpmd rules.

* fix: Fixed DriverInterface issue

* chore(release): 7.0.0-beta.1 [skip ci]

# [7.0.0-beta.1](https://github.com/EmicoEcommerce/Magento2TweakwiseExport/compare/v6.0.2...v7.0.0-beta.1) (2024-03-29)

### Bug Fixes

* Fixed DriverInterface issue ([a6d0109](https://github.com/EmicoEcommerce/Magento2TweakwiseExport/commit/a6d01098c246b2a3b3475ed0d3060d4de75f2817))
* use id instead of SKU ([#39](https://github.com/EmicoEcommerce/Magento2TweakwiseExport/issues/39)) ([7b325cb](https://github.com/EmicoEcommerce/Magento2TweakwiseExport/commit/7b325cba4e7b4f2c6de1227b64dac09e73a6cb6c))

### Performance Improvements

* Applied phpcs and phpmd rules ([d7e82dd](https://github.com/EmicoEcommerce/Magento2TweakwiseExport/commit/d7e82ddc47affc9506fed9f4013036693e96d605))

### BREAKING CHANGES

* Code is refactored based on phpcs and phpmd rules.

* fix: Fixed issue in FeedContent construct

* chore(release): 7.0.0-beta.1 [skip ci]

# [7.0.0-beta.1](https://github.com/EmicoEcommerce/Magento2TweakwiseExport/compare/v6.0.2...v7.0.0-beta.1) (2024-04-05)

### Bug Fixes

* Fixed DriverInterface issue ([a6d0109](https://github.com/EmicoEcommerce/Magento2TweakwiseExport/commit/a6d01098c246b2a3b3475ed0d3060d4de75f2817))
* Fixed issue in FeedContent construct ([d289fd3](https://github.com/EmicoEcommerce/Magento2TweakwiseExport/commit/d289fd3f1afca23dba3421461c9ae3d71c22be21))
* use id instead of SKU ([#39](https://github.com/EmicoEcommerce/Magento2TweakwiseExport/issues/39)) ([7b325cb](https://github.com/EmicoEcommerce/Magento2TweakwiseExport/commit/7b325cba4e7b4f2c6de1227b64dac09e73a6cb6c))

### Performance Improvements

* Applied phpcs and phpmd rules ([d7e82dd](https://github.com/EmicoEcommerce/Magento2TweakwiseExport/commit/d7e82ddc47affc9506fed9f4013036693e96d605))

### BREAKING CHANGES

* Code is refactored based on phpcs and phpmd rules.

* chore: Changed release job permissions

* chore(release): 7.0.0-beta.1 [skip ci]

# [7.0.0-beta.1](https://github.com/EmicoEcommerce/Magento2TweakwiseExport/compare/v6.0.2...v7.0.0-beta.1) (2024-04-05)

### Bug Fixes

* Fixed DriverInterface issue ([a6d0109](https://github.com/EmicoEcommerce/Magento2TweakwiseExport/commit/a6d01098c246b2a3b3475ed0d3060d4de75f2817))
* Fixed issue in FeedContent construct ([d289fd3](https://github.com/EmicoEcommerce/Magento2TweakwiseExport/commit/d289fd3f1afca23dba3421461c9ae3d71c22be21))
* use id instead of SKU ([#39](https://github.com/EmicoEcommerce/Magento2TweakwiseExport/issues/39)) ([7b325cb](https://github.com/EmicoEcommerce/Magento2TweakwiseExport/commit/7b325cba4e7b4f2c6de1227b64dac09e73a6cb6c))

### Performance Improvements

* Applied phpcs and phpmd rules ([d7e82dd](https://github.com/EmicoEcommerce/Magento2TweakwiseExport/commit/d7e82ddc47affc9506fed9f4013036693e96d605))

### BREAKING CHANGES

* Code is refactored based on phpcs and phpmd rules.

* Bump version nr

* chore(release): 7.0.0-beta.1 [skip ci]

# [7.0.0-beta.1](https://github.com/EmicoEcommerce/Magento2TweakwiseExport/compare/v6.0.2...v7.0.0-beta.1) (2024-04-09)

### Bug Fixes

* Fixed DriverInterface issue ([a6d0109](https://github.com/EmicoEcommerce/Magento2TweakwiseExport/commit/a6d01098c246b2a3b3475ed0d3060d4de75f2817))
* Fixed issue in FeedContent construct ([d289fd3](https://github.com/EmicoEcommerce/Magento2TweakwiseExport/commit/d289fd3f1afca23dba3421461c9ae3d71c22be21))
* use id instead of SKU ([#39](https://github.com/EmicoEcommerce/Magento2TweakwiseExport/issues/39)) ([7b325cb](https://github.com/EmicoEcommerce/Magento2TweakwiseExport/commit/7b325cba4e7b4f2c6de1227b64dac09e73a6cb6c))

### Performance Improvements

* Applied phpcs and phpmd rules ([d7e82dd](https://github.com/EmicoEcommerce/Magento2TweakwiseExport/commit/d7e82ddc47affc9506fed9f4013036693e96d605))

### BREAKING CHANGES

* Code is refactored based on phpcs and phpmd rules.

* fix: use id instead of SKU (#39)

Use entity_id in the WHERE clause instead of sku. This adjustment enhances the query's speed, especially when dealing with a large number of products.

During local testing, the export time decreased significantly from 50 minutes to just 8 minutes. Resulting in an increase in speed of 84%. This speed increase only seems to occur if you don't have all numbers as sku's.

* chore(release): 7.0.0-beta.1 [skip ci]

# [7.0.0-beta.1](https://github.com/EmicoEcommerce/Magento2TweakwiseExport/compare/v6.0.2...v7.0.0-beta.1) (2024-04-09)

### Bug Fixes

* Fixed DriverInterface issue ([a6d0109](https://github.com/EmicoEcommerce/Magento2TweakwiseExport/commit/a6d01098c246b2a3b3475ed0d3060d4de75f2817))
* Fixed issue in FeedContent construct ([d289fd3](https://github.com/EmicoEcommerce/Magento2TweakwiseExport/commit/d289fd3f1afca23dba3421461c9ae3d71c22be21))
* use id instead of SKU ([#39](https://github.com/EmicoEcommerce/Magento2TweakwiseExport/issues/39)) ([389dad7](https://github.com/EmicoEcommerce/Magento2TweakwiseExport/commit/389dad739f137a2fe221c93bda6bb4bccae7aa6d))
* use id instead of SKU ([#39](https://github.com/EmicoEcommerce/Magento2TweakwiseExport/issues/39)) ([7b325cb](https://github.com/EmicoEcommerce/Magento2TweakwiseExport/commit/7b325cba4e7b4f2c6de1227b64dac09e73a6cb6c))

### Performance Improvements

* Applied phpcs and phpmd rules ([d7e82dd](https://github.com/EmicoEcommerce/Magento2TweakwiseExport/commit/d7e82ddc47affc9506fed9f4013036693e96d605))

### BREAKING CHANGES

* Code is refactored based on phpcs and phpmd rules.

* fix: use id instead of SKU #39

Use entity_id in the WHERE clause instead of sku. This adjustment enhances the query's speed, especially when dealing with a large number of products.

During local testing, the export time decreased significantly from 50 minutes to just 8 minutes. Resulting in an increase in speed of 84%. This speed increase only seems to occur if you don't have all numbers as sku's.

* chore(release): 7.0.0-beta.2 [skip ci]

# [7.0.0-beta.2](https://github.com/EmicoEcommerce/Magento2TweakwiseExport/compare/v7.0.0-beta.1...v7.0.0-beta.2) (2024-04-09)

### Bug Fixes

* use id instead of SKU [#39](https://github.com/EmicoEcommerce/Magento2TweakwiseExport/issues/39) ([3576069](https://github.com/EmicoEcommerce/Magento2TweakwiseExport/commit/35760698039cbef9efa9ce5570fa084135089c48))

* perf: Applied phpcs and phpmd rules

BREAKING CHANGE: Code is refactored based on phpcs and phpmd rules. #37 #36

* fix: use id instead of sku #39

Use entity_id in the WHERE clause instead of sku. This adjustment enhances the query's speed, especially when dealing with a large number of products.

During local testing, the export time decreased significantly from 50 minutes to just 8 minutes. Resulting in an increase in speed of 84%. This speed increase only seems to occur if you don't have all numbers as sku's.

* chore(release): 7.0.0-beta.3 [skip ci]

# [7.0.0-beta.3](https://github.com/EmicoEcommerce/Magento2TweakwiseExport/compare/v7.0.0-beta.2...v7.0.0-beta.3) (2024-04-10)

### Bug Fixes

* use id instead of sku [#39](https://github.com/EmicoEcommerce/Magento2TweakwiseExport/issues/39) ([7f8fa8a](https://github.com/EmicoEcommerce/Magento2TweakwiseExport/commit/7f8fa8ab19cb024d280210d168713a61be0da2e9))

### Performance Improvements

* Applied phpcs and phpmd rules ([dad3813](https://github.com/EmicoEcommerce/Magento2TweakwiseExport/commit/dad3813f743f615d5459c5eb78be3f5109044efa))

### BREAKING CHANGES

* Code is refactored based on phpcs and phpmd rules. #37 #36

---------