### PR TITLE
Make installable on PHP 8.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": ">=8.0 <8.3",
+        "php": ">=8.0",
         "laminas/laminas-http": "^2.15.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": ">=8.0",
+        "php": "^8.0",
         "laminas/laminas-http": "^2.15.0"
     },
     "require-dev": {


### PR DESCRIPTION
New PHP subversions hardly ever break, remove the hard upper version constraint.