### PR TITLE
Tweakwise export fails due to incorrect return type used

### DIFF
--- a/Model/Write/Products/ExportEntity.php
+++ b/Model/Write/Products/ExportEntity.php
@@ -398,7 +398,7 @@ class ExportEntity
      */
     protected function isInStock(): bool
     {
-        return $this->getStockItem() !== null ? $this->getStockItem()->getIsInStock() : false;
+        return $this->getStockItem() !== null ? (bool) $this->getStockItem()->getIsInStock() : false;
     }
 
     /**


### PR DESCRIPTION
Since getIsInStock returns an int its value needs to type casted into a boolean