### PR TITLE
fix: stock behavior for grouped products

### DIFF
--- a/Model/Write/Products/ExportEntity.php
+++ b/Model/Write/Products/ExportEntity.php
@@ -398,7 +398,7 @@ class ExportEntity
      */
     protected function isInStock(): bool
     {
-        return $this->getStockItem() !== null ? $this->getStockItem()->getIsInStock() : false;
+        return $this->getStockItem() !== null ? (bool) $this->getStockItem()->getIsInStock() : false;
     }
 
     /**

--- a/Traits/Stock/HasStockThroughChildren.php
+++ b/Traits/Stock/HasStockThroughChildren.php
@@ -4,6 +4,7 @@ namespace Tweakwise\Magento2TweakwiseExport\Traits\Stock;
 
 use Tweakwise\Magento2TweakwiseExport\Model\StockItem;
 use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
+use Magento\GroupedProduct\Model\Product\Type\Grouped;
 
 /**
  * Trait HasChildren
@@ -40,7 +41,8 @@ trait HasStockThroughChildren
         $qty = (int) array_sum($childQty);
         $isInStock = min(
             max($childStockStatus),
-            $this->getTypeId() === Configurable::TYPE_CODE ? 1 : $this->stockItem->getIsInStock()
+            in_array($this->getTypeId(), [Configurable::TYPE_CODE, Grouped::TYPE_CODE], true) ? 1
+                : $this->stockItem->getIsInStock()
         );
         $stockItem = new StockItem();
         $stockItem->setQty($qty);


### PR DESCRIPTION
Merge pull request #73 from Hnto/beta
fix: type case int to boolean since shouldExportByStock only has boolean as return type

fix: stock behavior for grouped products
Fixing issue #68 (grouped products should be in stock if at least one child is in stock)