### PR TITLE
fix: export children by website

### DIFF
--- a/Model/Write/Products/CollectionDecorator/Children.php
+++ b/Model/Write/Products/CollectionDecorator/Children.php
@@ -92,7 +92,8 @@ class Children implements DecoratorInterface
         CollectionFactory $collectionFactory,
         Helper $helper,
         DbResourceHelper $dbResource,
-        TweakwiseConfig $config
+        TweakwiseConfig $config,
+        private readonly WebsiteLink $websiteLink
     ) {
         $this->productType = $productType;
         $this->eavIteratorFactory = $eavIteratorFactory;
@@ -113,6 +114,7 @@ class Children implements DecoratorInterface
     {
         $this->childEntities = $this->collectionFactory->create(['store' => $collection->getStore()]);
         $this->createChildEntities($collection);
+        $this->websiteLink->decorate($this->childEntities);
         $this->loadChildAttributes($collection->getStore());
     }
 

--- a/Model/Write/Products/CollectionDecorator/Children.php
+++ b/Model/Write/Products/CollectionDecorator/Children.php
@@ -83,6 +83,7 @@ class Children implements DecoratorInterface
      * @param Helper $helper
      * @param DbResourceHelper $dbResource
      * @param TweakwiseConfig $config
+     * @param WebsiteLink $websiteLink
      */
     public function __construct(
         ProductType $productType,

--- a/Model/Write/Products/CompositeExportEntity.php
+++ b/Model/Write/Products/CompositeExportEntity.php
@@ -71,7 +71,7 @@ class CompositeExportEntity extends ExportEntity implements CompositeExportEntit
         $this->enabledChildren = [];
 
         foreach ($this->getAllChildren() as $child) {
-            if ($child->shouldExportByStatus()) {
+            if ($child->shouldExport()) {
                 $this->enabledChildren[] = $child;
             }
         }

--- a/Model/Write/Products/ExportEntityChild.php
+++ b/Model/Write/Products/ExportEntityChild.php
@@ -71,7 +71,8 @@ class ExportEntityChild extends ExportEntity
     public function shouldExport(): bool
     {
         return $this->shouldExportByStock()
-            && $this->shouldExportByStatus();
+            && $this->shouldExportByStatus() &&
+            $this->shouldExportByWebsite();
     }
 
     /**


### PR DESCRIPTION
When an child product is not saleable in an website, it should not be exported. This pull requests add an website check on child level.