### PR TITLE
feat: Optionally skip children by Composite Product Type

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -39,6 +39,7 @@ class Config
     public const BATCH_SIZE_CATEGORIES = 'tweakwise/export/batch_size_categories';
     public const BATCH_SIZE_PRODUCTS = 'tweakwise/export/batch_size_products';
     public const BATCH_SIZE_PRODUCTS_CHILDREN = 'tweakwise/export/batch_size_products_children';
+    public const PATH_SKIP_CHILD_BY_COMPOSITE_TYPE = 'tweakwise/export/skip_child_by_composite_type';
 
     /**
      * Default feed filename
@@ -210,6 +211,20 @@ class Config
     }
 
     /**
+     * @param Store|int|string|null $store
+     * @return string[]
+     */
+    public function getSkipChildByCompositeTypes($store = null): array
+    {
+        $data = explode(
+            ',',
+            $this->config->getValue(self::PATH_SKIP_CHILD_BY_COMPOSITE_TYPE, ScopeInterface::SCOPE_STORE, $store)
+        );
+
+        return array_filter($data);
+    }
+
+    /**
      * @param StoreInterface|null $store
      * @param string|null $type
      * @return string
@@ -286,4 +301,5 @@ class Config
     {
         return (int) $this->config->getValue(self::BATCH_SIZE_PRODUCTS_CHILDREN);
     }
+
 }

--- a/Model/Write/Products/CollectionDecorator/ChildrenAttributes.php
+++ b/Model/Write/Products/CollectionDecorator/ChildrenAttributes.php
@@ -35,6 +35,15 @@ class ChildrenAttributes implements DecoratorInterface
             if (!$exportEntity instanceof CompositeExportEntityInterface) {
                 continue;
             }
+            if (
+                in_array(
+                    $exportEntity->getTypeId(),
+                    $this->config->getSkipChildByCompositeTypes($exportEntity->getStore()),
+                    true
+                )
+            ) {
+                continue;
+            }
 
             foreach ($exportEntity->getExportChildren() as $child) {
                 foreach ($child->getAttributes() as $attributeData) {

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -92,6 +92,14 @@
                         <field id="enabled">1</field>
                     </depends>
                 </field>
+                <field id="skip_child_by_composite_type" translate="label,comment" type="multiselect" sortOrder="95" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Skip children for composite type(s)</label>
+                    <comment>Selected composite type(s) will exclude attributes from its children.</comment>
+                    <source_model>Tweakwise\Magento2TweakwiseExport\Model\Config\Source\CompositeTypes</source_model>
+                    <depends>
+                        <field id="enabled">1</field>
+                    </depends>
+                </field>
 
                 <field id="price_field" translate="label,comment" type="select" sortOrder="100" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Price field</label>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -21,6 +21,7 @@
                 <stock_calculation>sum</stock_calculation>
                 <out_of_stock_children>1</out_of_stock_children>
                 <exclude_child_attributes>url_key,small_image,small_image_label,thumbnail_label,status,tax_class_id,type_id,required_options,visibility</exclude_child_attributes>
+                <skip_child_by_composite_type/>
                 <price_field>min_price,final_price,price,max_price</price_field>
                 <batch_size_categories>5000</batch_size_categories>
                 <batch_size_products>5000</batch_size_products>


### PR DESCRIPTION
MR for: https://github.com/EmicoEcommerce/Magento2TweakwiseExport/issues/83

In some cases you might want to skip child attribute values for certain composite product types. In our case we would like to skip child attribute values for grouped products. The individual children are already listed / filterable, including this data in the grouped products as well pollute the search results and filters. Especially if the grouped products contain different product types, which causes filters from all children to be displayed on all pages with the grouped product.

Configuration path: `tweakwise/export/skip_child_by_composite_type` (for example `grouped` or `grouped,bundle`)