### PR TITLE
fix:price export

### DIFF
--- a/Model/Write/Price.php
+++ b/Model/Write/Price.php
@@ -154,6 +154,11 @@ class Price implements WriterInterface
      */
     protected function writeProduct(XMLWriter $xml, $storeId, array $data): void
     {
+        //don't export products without price, this can happen when the price isn't in the price index table.
+        if ($data['price'] === 0.0) {
+            return;
+        }
+
         $xml->startElement('item');
 
         // Write product base data

--- a/Model/Write/Price.php
+++ b/Model/Write/Price.php
@@ -155,7 +155,7 @@ class Price implements WriterInterface
     protected function writeProduct(XMLWriter $xml, $storeId, array $data): void
     {
         //don't export products without price, this can happen when the price isn't in the price index table.
-        if ($data['price'] === 0.0) {
+        if ($data['price'] === null) {
             return;
         }
 

--- a/Model/Write/Price/ExportEntity.php
+++ b/Model/Write/Price/ExportEntity.php
@@ -50,7 +50,7 @@ class ExportEntity
     /**
      * @var float
      */
-    protected $price = 0.0;
+    protected $price = null;
 
     /**
      * @var StockItem
@@ -182,10 +182,14 @@ class ExportEntity
     }
 
     /**
-     * @return float
+     * @return float|null
      */
-    public function getPrice(): float
+    public function getPrice(): float|null
     {
+        if ($this->price === null) {
+            return null;
+        }
+
         return (float) $this->price;
     }
 

--- a/Model/Write/Price/ExportEntity.php
+++ b/Model/Write/Price/ExportEntity.php
@@ -184,7 +184,7 @@ class ExportEntity
     /**
      * @return float|null
      */
-    public function getPrice(): float|null
+    public function getPrice(): ?float
     {
         if ($this->price === null) {
             return null;

--- a/Model/Write/Products.php
+++ b/Model/Write/Products.php
@@ -160,7 +160,7 @@ class Products implements WriterInterface
         $tweakwiseId = $this->helper->getTweakwiseId($storeId, $data['entity_id']);
         $xml->writeElement('id', $tweakwiseId);
         $xml->writeElement('name', $this->scalarValue($data['name']));
-        $xml->writeElement('price', $this->scalarValue($data['price']));
+        $xml->writeElement('price', $this->scalarValue((float)$data['price']));
         $xml->writeElement('stock', $this->scalarValue($data['stock']));
 
         // Write product categories


### PR DESCRIPTION
When an products price is missing from the price index table, the product gets exported with an 0.0 price. This pull request fixes that by not exporting the price if it is null. 

The price is now initialized as null instead of 0.0. And if the price is null, it is not exported. If the price is retrieved from the price table and is 0.0 then the price gets exported. This only skips prices not available in the indexed table.
To prevent from exporting null prices in the normal export, the price is cast as an float when writing to the feed.

The price can be missing from the price index table for various reasons. Magento can be indexing the prices. Or the visibiltiy/enabled status of the product has changed and caused the price not to be indexed anymore.