### PR TITLE
feat: calculate group/bundle prices incl/excl vat

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -309,19 +309,19 @@ class Config
     }
 
     /**
-     * @param Store|int|string|null $store
+     * @param Store $store
      * @return bool
      */
-    public function calculateCombinedPrices($store = null): bool
+    public function calculateCombinedPrices(Store $store): bool
     {
         return (bool) $this->config->isSetFlag(self::CALCULATE_COMPOSITE_PRICES, ScopeInterface::SCOPE_STORE, $store);
     }
 
     /**
-     * @param Store|int|string|null $store
+     * @param Store $store
      * @return bool
      */
-    public function addVat($store = null): bool
+    public function addVat(Store $store): bool
     {
         return (bool) $this->config->isSetFlag(self::ADD_TAX_TO_PRICES, ScopeInterface::SCOPE_STORE, $store);
     }

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -40,6 +40,8 @@ class Config
     public const BATCH_SIZE_PRODUCTS = 'tweakwise/export/batch_size_products';
     public const BATCH_SIZE_PRODUCTS_CHILDREN = 'tweakwise/export/batch_size_products_children';
     public const PATH_SKIP_CHILD_BY_COMPOSITE_TYPE = 'tweakwise/export/skip_child_by_composite_type';
+    public const CALCULATE_COMPOSITE_PRICES = 'tweakwise/export/calculate_composite_prices';
+    public const ADD_TAX_TO_PRICES = 'tweakwise/export/add_tax_to_prices';
 
     /**
      * Default feed filename
@@ -304,5 +306,15 @@ class Config
     public function getBatchSizeProductsChildren(): int
     {
         return (int) $this->config->getValue(self::BATCH_SIZE_PRODUCTS_CHILDREN);
+    }
+
+    public function calculateCombinedPrices($store = null): bool
+    {
+        return (bool) $this->config->isSetFlag(self::CALCULATE_COMPOSITE_PRICES, ScopeInterface::SCOPE_STORE, $store);
+    }
+
+    public function addVat($store = null): bool
+    {
+        return (bool) $this->config->isSetFlag(self::ADD_TAX_TO_PRICES, ScopeInterface::SCOPE_STORE, $store);
     }
 }

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -308,11 +308,19 @@ class Config
         return (int) $this->config->getValue(self::BATCH_SIZE_PRODUCTS_CHILDREN);
     }
 
+    /**
+     * @param Store|int|string|null $store
+     * @return bool
+     */
     public function calculateCombinedPrices($store = null): bool
     {
         return (bool) $this->config->isSetFlag(self::CALCULATE_COMPOSITE_PRICES, ScopeInterface::SCOPE_STORE, $store);
     }
 
+    /**
+     * @param Store|int|string|null $store
+     * @return bool
+     */
     public function addVat($store = null): bool
     {
         return (bool) $this->config->isSetFlag(self::ADD_TAX_TO_PRICES, ScopeInterface::SCOPE_STORE, $store);

--- a/Model/Write/Price/IteratorInitializer.php
+++ b/Model/Write/Price/IteratorInitializer.php
@@ -34,5 +34,6 @@ class IteratorInitializer
         $iterator->selectAttribute('status');
         $iterator->selectAttribute('visibility');
         $iterator->selectAttribute('type_id');
+        $iterator->selectAttribute('tax_class_id');
     }
 }

--- a/Model/Write/Products/CollectionDecorator/Price.php
+++ b/Model/Write/Products/CollectionDecorator/Price.php
@@ -260,7 +260,12 @@ class Price implements DecoratorInterface
      * @param int|null $taxClassId
      * @return float
      */
-    protected function calculateProductPrice(int $entityId, callable $getAssociatedItems, $store, ?int $taxClassId): float
+    protected function calculateProductPrice(
+        int $entityId,
+        callable $getAssociatedItems,
+        $store,
+        ?int $taxClassId
+    ): float
     {
         $product = $this->collectionFactory->create()->getItemById($entityId);
         $associatedItems = $getAssociatedItems($product);
@@ -270,16 +275,19 @@ class Price implements DecoratorInterface
             $associatedItems = $associatedItems->getItems();
         }
 
-        return array_reduce($associatedItems, function ($total, $item) use ($store, $taxClassId) {
-            $basePrice = $item->getPrice();
-            $price = $this->calculatePrice(
-                $basePrice,
-                $taxClassId,
-                $store
-            );
-
-            return $total + ($price * $item->getQty());
-        }, 0);
+        return array_reduce(
+            $associatedItems,
+            function ($total, $item) use ($store, $taxClassId) {
+                $basePrice = $item->getPrice();
+                $price = $this->calculatePrice(
+                    $basePrice,
+                    $taxClassId,
+                    $store
+                );
+                return $total + ($price * $item->getQty());
+            },
+            0
+        );
     }
 
     /**
@@ -290,10 +298,14 @@ class Price implements DecoratorInterface
      */
     protected function calculateGroupedProductPrice(int $entityId, $store, ?int $taxClassId): float
     {
-        return $this->calculateProductPrice($entityId, function ($product) {
-            return $product->getTypeInstance()->getAssociatedProducts($product);
-        }
-        , $store, $taxClassId);
+        return $this->calculateProductPrice(
+            $entityId,
+            function ($product) {
+                return $product->getTypeInstance()->getAssociatedProducts($product);
+            },
+            $store,
+            $taxClassId
+        );
     }
 
     /**
@@ -304,12 +316,16 @@ class Price implements DecoratorInterface
      */
     protected function calculateBundleProductPrice(int $entityId, $store, ?int $taxClassId): float
     {
-        return $this->calculateProductPrice($entityId, function ($product) {
-            return $product->getTypeInstance()->getSelectionsCollection(
-                $product->getTypeInstance()->getOptionsIds($product),
-                $product
-            );
-        }
-        , $store, $taxClassId);
+        return $this->calculateProductPrice(
+            $entityId,
+            function ($product) {
+                return $product->getTypeInstance()->getSelectionsCollection(
+                    $product->getTypeInstance()->getOptionsIds($product),
+                    $product
+                );
+            },
+            $store,
+            $taxClassId
+        );
     }
 }

--- a/Model/Write/Products/CollectionDecorator/Price.php
+++ b/Model/Write/Products/CollectionDecorator/Price.php
@@ -3,8 +3,10 @@
 namespace Tweakwise\Magento2TweakwiseExport\Model\Write\Products\CollectionDecorator;
 
 // phpcs:disable Magento2.Legacy.RestrictedCode.ZendDbSelect
+use Magento\Bundle\Model\Product\Type;
 use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\GroupedProduct\Model\Product\Type\Grouped;
 use Magento\Tax\Model\Calculation;
 use Tweakwise\Magento2TweakwiseExport\Exception\InvalidArgumentException;
 use Tweakwise\Magento2TweakwiseExport\Model\Config;
@@ -15,6 +17,7 @@ use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
 use Magento\Store\Model\StoreManagerInterface;
 use Zend_Db_Select;
 use Magento\Tax\Model\TaxCalculation;
+use Magento\Framework\Data\Collection as DataCollection;
 
 class Price implements DecoratorInterface
 {
@@ -241,7 +244,7 @@ class Price implements DecoratorInterface
      */
     protected function isGroupedProduct(ProductInterface $product): bool
     {
-        return $product?->getTypeId() === \Magento\GroupedProduct\Model\Product\Type\Grouped::TYPE_CODE;
+        return $product?->getTypeId() === Grouped::TYPE_CODE;
     }
 
     /**
@@ -250,7 +253,7 @@ class Price implements DecoratorInterface
      */
     protected function isBundleProduct($product): bool
     {
-        return $product?->getTypeId() === \Magento\Bundle\Model\Product\Type::TYPE_CODE;
+        return $product?->getTypeId() === Type::TYPE_CODE;
     }
 
     /**
@@ -270,7 +273,7 @@ class Price implements DecoratorInterface
         $associatedItems = $getAssociatedItems($product);
 
         // Convert collection to array if necessary
-        if ($associatedItems instanceof \Magento\Framework\Data\Collection) {
+        if ($associatedItems instanceof DataCollection) {
             $associatedItems = $associatedItems->getItems();
         }
 

--- a/Model/Write/Products/CollectionDecorator/Price.php
+++ b/Model/Write/Products/CollectionDecorator/Price.php
@@ -24,8 +24,6 @@ use Magento\Store\Model\ScopeInterface;
 
 class Price implements DecoratorInterface
 {
-    private const XML_PATH_ROUNDING_METHOD = 'tax/calculation/rounding_method';
-
     /**
      * @var CollectionFactory
      */
@@ -45,11 +43,6 @@ class Price implements DecoratorInterface
      * @var float
      */
     private float $exchangeRate = 1.0;
-
-    /**
-     * @var string|null
-     */
-    private ?string $roundingMethod = null;
 
     /**
      * Price constructor.
@@ -89,11 +82,6 @@ class Price implements DecoratorInterface
         }
 
         $this->exchangeRate = $exchangeRate ?? 1.0;
-        $this->roundingMethod = $this->scopeConfig->getValue(
-            self::XML_PATH_ROUNDING_METHOD,
-            ScopeInterface::SCOPE_STORE,
-            $store->getCode()
-        );
 
         $priceFields = $this->config->getPriceFields($collection->getStore()->getId());
 
@@ -125,11 +113,7 @@ class Price implements DecoratorInterface
      */
     private function applyRoundingMethod(float $value): float
     {
-        return match ($this->roundingMethod) {
-            'ceil' => ceil($value),
-            'floor' => floor($value),
-            default => round($value, 2),
-        };
+        return round($value, 2);
     }
 
     /**
@@ -161,8 +145,7 @@ class Price implements DecoratorInterface
         $taxRate = $this->taxCalculation->getRate($rateRequest->setProductClassId($taxClassId));
 
         $price = $this->applyRoundingMethod(
-            $price * (1 + $taxRate / 100),
-            $this->roundingMethod
+            $price * (1 + $taxRate / 100)
         );
 
         return $price;
@@ -175,8 +158,7 @@ class Price implements DecoratorInterface
     private function calculateExchangeRate(float $price): float
     {
         return $this->applyRoundingMethod(
-            $price * $this->exchangeRate,
-            $this->roundingMethod
+            $price * $this->exchangeRate
         );
     }
 

--- a/Model/Write/Products/CollectionDecorator/Price.php
+++ b/Model/Write/Products/CollectionDecorator/Price.php
@@ -265,8 +265,7 @@ class Price implements DecoratorInterface
         callable $getAssociatedItems,
         $store,
         ?int $taxClassId
-    ): float
-    {
+    ): float {
         $product = $this->collectionFactory->create()->getItemById($entityId);
         $associatedItems = $getAssociatedItems($product);
 

--- a/Model/Write/Products/CollectionDecorator/Price.php
+++ b/Model/Write/Products/CollectionDecorator/Price.php
@@ -19,6 +19,7 @@ use Magento\Tax\Model\TaxCalculation;
 class Price implements DecoratorInterface
 {
     private const XML_PATH_ROUNDING_METHOD = 'tax/calculation/rounding_method';
+
     /**
      * @var CollectionFactory
      */
@@ -80,8 +81,13 @@ class Price implements DecoratorInterface
         if ($collection->getStore()->getCurrentCurrencyRate() > 0.00001) {
             $exchangeRate = (float)$collection->getStore()->getCurrentCurrencyRate();
         }
+
         $this->exchangeRate = $exchangeRate ?? 1.0;
-        $this->roundingMethod = $this->scopeConfig->getValue(self::XML_PATH_ROUNDING_METHOD, \Magento\Store\Model\ScopeInterface::SCOPE_STORE, $store->getCode());
+        $this->roundingMethod = $this->scopeConfig->getValue(
+            self::XML_PATH_ROUNDING_METHOD,
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+            $store->getCode()
+        );
 
         $priceFields = $this->config->getPriceFields($collection->getStore()->getId());
 
@@ -166,8 +172,6 @@ class Price implements DecoratorInterface
             $price * $this->exchangeRate,
             $this->roundingMethod
         );
-
-        return $price;
     }
 
     /**
@@ -224,6 +228,7 @@ class Price implements DecoratorInterface
             if (isset($product->getAttribute('tax_class_id')[0])) {
                 return $product->getAttribute('tax_class_id')[0];
             }
+
             return null;
         } catch (InvalidArgumentException) {
             return null;
@@ -286,9 +291,9 @@ class Price implements DecoratorInterface
     protected function calculateGroupedProductPrice(int $entityId, $store, ?int $taxClassId): float
     {
         return $this->calculateProductPrice($entityId, function ($product) {
-
             return $product->getTypeInstance()->getAssociatedProducts($product);
-        }, $store, $taxClassId);
+        }
+        , $store, $taxClassId);
     }
 
     /**
@@ -300,11 +305,11 @@ class Price implements DecoratorInterface
     protected function calculateBundleProductPrice(int $entityId, $store, ?int $taxClassId): float
     {
         return $this->calculateProductPrice($entityId, function ($product) {
-
             return $product->getTypeInstance()->getSelectionsCollection(
                 $product->getTypeInstance()->getOptionsIds($product),
                 $product
             );
-        }, $store, $taxClassId);
+        }
+        , $store, $taxClassId);
     }
 }

--- a/Model/Write/Products/CollectionDecorator/Price.php
+++ b/Model/Write/Products/CollectionDecorator/Price.php
@@ -3,6 +3,10 @@
 namespace Tweakwise\Magento2TweakwiseExport\Model\Write\Products\CollectionDecorator;
 
 // phpcs:disable Magento2.Legacy.RestrictedCode.ZendDbSelect
+use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Tax\Model\Calculation;
+use Tweakwise\Magento2TweakwiseExport\Exception\InvalidArgumentException;
 use Tweakwise\Magento2TweakwiseExport\Model\Config;
 use Tweakwise\Magento2TweakwiseExport\Model\Write\Products\Collection;
 use Magento\Catalog\Model\ResourceModel\Product\Collection as ProductCollection;
@@ -10,9 +14,11 @@ use Tweakwise\Magento2TweakwiseExport\Model\Write\Price\Collection as PriceColle
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
 use Magento\Store\Model\StoreManagerInterface;
 use Zend_Db_Select;
+use Magento\Tax\Model\TaxCalculation;
 
 class Price implements DecoratorInterface
 {
+    private const XML_PATH_ROUNDING_METHOD = 'tax/calculation/rounding_method';
     /**
      * @var CollectionFactory
      */
@@ -29,15 +35,29 @@ class Price implements DecoratorInterface
     protected $config;
 
     /**
+     * @var float
+     */
+    private float $exchangeRate = 1.0;
+
+    /**
+     * @var string|null
+     */
+    private ?string $roundingMethod = null;
+
+    /**
      * Price constructor.
      * @param CollectionFactory $collectionFactory
      * @param StoreManagerInterface $storeManager
      * @param Config $config
+     * @param Calculation $taxCalculation
+     * @param ScopeConfigInterface $scopeConfig
      */
     public function __construct(
         CollectionFactory $collectionFactory,
         StoreManagerInterface $storeManager,
-        Config $config
+        Config $config,
+        private readonly Calculation $taxCalculation,
+        private readonly ScopeConfigInterface $scopeConfig
     ) {
         $this->collectionFactory = $collectionFactory;
         $this->storeManager = $storeManager;
@@ -50,16 +70,18 @@ class Price implements DecoratorInterface
      */
     public function decorate(Collection|PriceCollection $collection): void
     {
+        $store = $collection->getStore();
         $websiteId = $collection->getStore()->getWebsiteId();
+
         $priceSelect = $this->createPriceSelect($collection->getIds(), $websiteId);
-
         $priceQuery = $priceSelect->getSelect()->query();
-        $currency = $collection->getStore()->getCurrentCurrency();
-        $exchangeRate = 1;
 
+        $currency = $collection->getStore()->getCurrentCurrency();
         if ($collection->getStore()->getCurrentCurrencyRate() > 0.00001) {
             $exchangeRate = (float)$collection->getStore()->getCurrentCurrencyRate();
         }
+        $this->exchangeRate = $exchangeRate ?? 1.0;
+        $this->roundingMethod = $this->scopeConfig->getValue(self::XML_PATH_ROUNDING_METHOD, \Magento\Store\Model\ScopeInterface::SCOPE_STORE, $store->getCode());
 
         $priceFields = $this->config->getPriceFields($collection->getStore()->getId());
 
@@ -68,13 +90,84 @@ class Price implements DecoratorInterface
             $row['currency'] = $currency->getCurrencyCode();
             $row['price'] = $this->getPriceValue($row, $priceFields);
 
-            //do all prices * exchange rate
-            foreach ($priceFields as $priceField) {
-                $row[$priceField] = (float) ($row[$priceField] * $exchangeRate);
+            $product = $this->collectionFactory->create()->getItemById($entityId);
+            $taxClassId = $this->getTaxClassId($collection->get($entityId));
+
+            if ($this->config->calculateCombinedPrices($store) && $this->isGroupedProduct($product)) {
+                $row['price'] = $this->calculateGroupedProductPrice($entityId, $store, $taxClassId);
+            } elseif ($this->config->calculateCombinedPrices($store) && $this->isBundleProduct($product)) {
+                $row['price'] = $this->calculateBundleProductPrice($entityId, $store, $taxClassId);
+            } else {
+                foreach ($priceFields as $priceField) {
+                    $row[$priceField] = $this->calculatePrice((float)$row[$priceField], $taxClassId, $store);
+                }
             }
 
             $collection->get($entityId)->setFromArray($row);
         }
+    }
+
+    /**
+     * @param float $value
+     * @return float
+     */
+    private function applyRoundingMethod(float $value): float
+    {
+        return match ($this->roundingMethod) {
+            'ceil' => ceil($value),
+            'floor' => floor($value),
+            default => round($value, 2),
+        };
+    }
+
+    /**
+     * @param float $price
+     * @param int|null $taxClassId
+     * @param Store $store
+     * @return float
+     */
+    private function calculatePrice(float $price, ?int $taxClassId, $store): float
+    {
+        if ($this->config->addVat($store)) {
+            $price = $this->addVat($price, $taxClassId, $store);
+        }
+
+        $price = $this->calculateExchangeRate($price);
+
+        return $price;
+    }
+
+    /**
+     * @param float $price
+     * @param int|null $taxClassId
+     * @param Store $store
+     * @return float
+     */
+    private function addVat(float $price, ?int $taxClassId, $store): float
+    {
+        $rateRequest = $this->taxCalculation->getRateRequest(null, null, null, $store);
+        $taxRate = $this->taxCalculation->getRate($rateRequest->setProductClassId($taxClassId));
+
+        $price = $this->applyRoundingMethod(
+            $price * (1 + $taxRate / 100),
+            $this->roundingMethod
+        );
+
+        return $price;
+    }
+
+    /**
+     * @param float $price
+     * @return float
+     */
+    private function calculateExchangeRate(float $price): float
+    {
+        return $this->applyRoundingMethod(
+            $price * $this->exchangeRate,
+            $this->roundingMethod
+        );
+
+        return $price;
     }
 
     /**
@@ -119,5 +212,99 @@ class Price implements DecoratorInterface
         }
 
         return 0;
+    }
+
+    /**
+     * @param ProductInterface $product
+     * @return int|null
+     */
+    protected function getTaxClassId($product): ?int
+    {
+        try {
+            if (isset($product->getAttribute('tax_class_id')[0])) {
+                return $product->getAttribute('tax_class_id')[0];
+            }
+            return null;
+        } catch (InvalidArgumentException) {
+            return null;
+        }
+    }
+
+    /**
+     * @param ProductInterface $product
+     * @return bool
+     */
+    protected function isGroupedProduct(ProductInterface $product): bool
+    {
+        return $product?->getTypeId() === \Magento\GroupedProduct\Model\Product\Type\Grouped::TYPE_CODE;
+    }
+
+    /**
+     * @param ProductInterface $product
+     * @return bool
+     */
+    protected function isBundleProduct($product): bool
+    {
+        return $product?->getTypeId() === \Magento\Bundle\Model\Product\Type::TYPE_CODE;
+    }
+
+    /**
+     * @param int $entityId
+     * @param callable $getAssociatedItems
+     * @param Store $store
+     * @param int|null $taxClassId
+     * @return float
+     */
+    protected function calculateProductPrice(int $entityId, callable $getAssociatedItems, $store, ?int $taxClassId): float
+    {
+        $product = $this->collectionFactory->create()->getItemById($entityId);
+        $associatedItems = $getAssociatedItems($product);
+
+        // Convert collection to array if necessary
+        if ($associatedItems instanceof \Magento\Framework\Data\Collection) {
+            $associatedItems = $associatedItems->getItems();
+        }
+
+        return array_reduce($associatedItems, function ($total, $item) use ($store, $taxClassId) {
+            $basePrice = $item->getPrice();
+            $price = $this->calculatePrice(
+                $basePrice,
+                $taxClassId,
+                $store
+            );
+
+            return $total + ($price * $item->getQty());
+        }, 0);
+    }
+
+    /**
+     * @param int $entityId
+     * @param Store $store
+     * @param int|null $taxClassId
+     * @return float
+     */
+    protected function calculateGroupedProductPrice(int $entityId, $store, ?int $taxClassId): float
+    {
+        return $this->calculateProductPrice($entityId, function ($product) {
+
+            return $product->getTypeInstance()->getAssociatedProducts($product);
+        }, $store, $taxClassId);
+    }
+
+    /**
+     * @param int $entityId
+     * @param Store $store
+     * @param int|null $taxClassId
+     * @return float
+     */
+    protected function calculateBundleProductPrice(int $entityId, $store, ?int $taxClassId): float
+    {
+        return $this->calculateProductPrice($entityId, function ($product) {
+
+            return $product->getTypeInstance()->getSelectionsCollection(
+                $product->getTypeInstance()->getOptionsIds($product),
+                $product
+            );
+        }, $store, $taxClassId);
     }
 }

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -111,7 +111,7 @@
                     </depends>
                 </field>
 
-                <field id="calculate_composite_prices" translate="label,comment" type="select" sortOrder="70" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="calculate_composite_prices" translate="label,comment" type="select" sortOrder="110" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Calculate combined prices</label>
                     <comment>Would you like to export the combined price of an grouped/bundle product?</comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
@@ -120,7 +120,7 @@
                     </depends>
                 </field>
 
-                <field id="add_tax_to_prices" translate="label,comment" type="select" sortOrder="70" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="add_tax_to_prices" translate="label,comment" type="select" sortOrder="120" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Export prices incl vat</label>
                     <comment>Add the vat to the prices exported. Only enable this if the prices exported to Tweakwise are missing the vat</comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
@@ -132,7 +132,7 @@
                 <field id="batch_size_categories"
                        translate="batch size for categories"
                        type="text"
-                       sortOrder="110"
+                       sortOrder="130"
                        showInDefault="1"
                        showInWebsite="0"
                        showInStore="0"
@@ -148,7 +148,7 @@
                 <field id="batch_size_products"
                        translate="batch size for products"
                        type="text"
-                       sortOrder="120"
+                       sortOrder="140"
                        showInDefault="1"
                        showInWebsite="0"
                        showInStore="0"
@@ -164,7 +164,7 @@
                 <field id="batch_size_products_children"
                        translate="batch size for products children"
                        type="text"
-                       sortOrder="130"
+                       sortOrder="150"
                        showInDefault="1"
                        showInWebsite="0"
                        showInStore="0"
@@ -177,7 +177,7 @@
                     </comment>
                 </field>
 
-                <field id="schedule" translate="label" type="text" sortOrder="140" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="schedule" translate="label" type="text" sortOrder="160" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Schedule full export</label>
                     <comment>Leave empty to disable export by cron.</comment>
                     <depends>
@@ -185,14 +185,14 @@
                         <field id="real_time">0</field>
                     </depends>
                 </field>
-                <field id="export_state" translate="label,comment" type="label" sortOrder="150" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="export_state" translate="label,comment" type="label" sortOrder="170" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>State</label>
                     <frontend_model>Tweakwise\Magento2TweakwiseExport\Block\Config\Form\Field\ExportState</frontend_model>
                     <depends>
                         <field id="enabled">1</field>
                     </depends>
                 </field>
-                <field id="start" translate="label,comment" type="label" sortOrder="160" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="start" translate="label,comment" type="label" sortOrder="180" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Schedule exports</label>
                     <frontend_model>Tweakwise\Magento2TweakwiseExport\Block\Config\Form\Field\ExportStart</frontend_model>
                     <comment>Start exports on next cron run</comment>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -111,6 +111,24 @@
                     </depends>
                 </field>
 
+                <field id="calculate_composite_prices" translate="label,comment" type="select" sortOrder="70" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Calculate combined prices</label>
+                    <comment>Would you like to export the combined price of an grouped/bundle product?</comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <depends>
+                        <field id="enabled">1</field>
+                    </depends>
+                </field>
+
+                <field id="add_tax_to_prices" translate="label,comment" type="select" sortOrder="70" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Export prices incl vat</label>
+                    <comment>Add the vat to the prices exported. Only enable this if the prices exported to Tweakwise are missing the vat</comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <depends>
+                        <field id="enabled">1</field>
+                    </depends>
+                </field>
+
                 <field id="batch_size_categories"
                        translate="batch size for categories"
                        type="text"

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -26,6 +26,8 @@
                 <batch_size_categories>5000</batch_size_categories>
                 <batch_size_products>5000</batch_size_products>
                 <batch_size_products_children>5000</batch_size_products_children>
+                <calculate_composite_prices>0</calculate_composite_prices>
+                <add_tax_to_price>0</add_tax_to_price>
             </export>
             <export_stock>
                 <enabled>0</enabled>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -27,7 +27,7 @@
                 <batch_size_products>5000</batch_size_products>
                 <batch_size_products_children>5000</batch_size_products_children>
                 <calculate_composite_prices>0</calculate_composite_prices>
-                <add_tax_to_price>0</add_tax_to_price>
+                <add_tax_to_prices>0</add_tax_to_prices>
             </export>
             <export_stock>
                 <enabled>0</enabled>


### PR DESCRIPTION
Add two settings for the export

- Calculate combined prices
When enabled the price exported in the price field to TW for grouped/bundle products is the total price of all products default in the group/bundle product. Not the minimum price of one of the products.

- Add vat to the export
When enabled the vat is added to the price. Only enable this if the price field in the TW export is missing the vat.
