### PR TITLE
feat: Export category URL

### DIFF
--- a/Model/Write/Categories.php
+++ b/Model/Write/Categories.php
@@ -185,7 +185,10 @@ class Categories implements WriterInterface
         $xml->writeElement('categoryid', $tweakwiseId);
         $xml->writeElement('rank', $data['position']);
         $xml->writeElement('name', $data['name']);
-        $xml->writeElement('url', $data['url'] ?? '');
+
+        if (isset($data['url'])) {
+            $xml->writeElement('url', $data['url']);
+        }
 
         if (isset($data['parent_id']) && $data['parent_id']) {
             $xml->startElement('parents');

--- a/Model/Write/Categories.php
+++ b/Model/Write/Categories.php
@@ -9,6 +9,7 @@
 
 namespace Tweakwise\Magento2TweakwiseExport\Model\Write;
 
+use Magento\Framework\UrlInterface;
 use Tweakwise\Magento2TweakwiseExport\Model\Config;
 use Tweakwise\Magento2TweakwiseExport\Model\Helper;
 use Tweakwise\Magento2TweakwiseExport\Model\Logger;
@@ -153,6 +154,10 @@ class Categories implements WriterInterface
                 continue;
             }
 
+            if (isset($data['url_path'])) {
+                $data['url'] = $this->getCategoryUrl($data['url_path'], $store);
+            }
+
             // Set category as exported
             $exportedCategories[$data['entity_id']] = true;
             $this->writeCategory($xml, $storeId, $data);
@@ -180,6 +185,7 @@ class Categories implements WriterInterface
         $xml->writeElement('categoryid', $tweakwiseId);
         $xml->writeElement('rank', $data['position']);
         $xml->writeElement('name', $data['name']);
+        $xml->writeElement('url', $data['url'] ?? '');
 
         if (isset($data['parent_id']) && $data['parent_id']) {
             $xml->startElement('parents');
@@ -198,5 +204,19 @@ class Categories implements WriterInterface
         }
 
         $xml->endElement(); // </category>
+    }
+
+    /**
+     * @param string $urlPath
+     * @param Store $store
+     * @return string
+     */
+    private function getCategoryUrl(string $urlPath, Store $store): string
+    {
+        return sprintf(
+            '%s%s',
+            $store->getBaseUrl(UrlInterface::URL_TYPE_WEB, true),
+            $urlPath
+        );
     }
 }

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -68,7 +68,6 @@
                 <item name="level" xsi:type="string">level</item>
                 <item name="position" xsi:type="string">position</item>
                 <item name="is_active" xsi:type="string">is_active</item>
-                <item name="url_path" xsi:type="string">url_path</item>
             </argument>
         </arguments>
     </type>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -68,6 +68,7 @@
                 <item name="level" xsi:type="string">level</item>
                 <item name="position" xsi:type="string">position</item>
                 <item name="is_active" xsi:type="string">is_active</item>
+                <item name="url_path" xsi:type="string">url_path</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
The Tweakwise JS module requires the full category URL. For this purpose, it has now been added to the export feed.
This is necessary so that the Tweakwise JS module can link to a full category URL via the filters instead of a URL with parameters. This is beneficial for SEO.