### PR TITLE
Fix: remove rounding and vat

### DIFF
--- a/Model/Write/Products/CollectionDecorator/Price.php
+++ b/Model/Write/Products/CollectionDecorator/Price.php
@@ -108,15 +108,6 @@ class Price implements DecoratorInterface
     }
 
     /**
-     * @param float $value
-     * @return float
-     */
-    private function applyRoundingMethod(float $value): float
-    {
-        return round($value, 2);
-    }
-
-    /**
      * @param float $price
      * @param int|null $taxClassId
      * @param Store $store
@@ -124,29 +115,7 @@ class Price implements DecoratorInterface
      */
     private function calculatePrice(float $price, ?int $taxClassId, Store $store): float
     {
-        if ($this->config->addVat($store)) {
-            $price = $this->addVat($price, $taxClassId, $store);
-        }
-
         $price = $this->calculateExchangeRate($price);
-
-        return $price;
-    }
-
-    /**
-     * @param float $price
-     * @param int|null $taxClassId
-     * @param Store $store
-     * @return float
-     */
-    private function addVat(float $price, ?int $taxClassId, Store $store): float
-    {
-        $rateRequest = $this->taxCalculation->getRateRequest(null, null, null, $store);
-        $taxRate = $this->taxCalculation->getRate($rateRequest->setProductClassId($taxClassId));
-
-        $price = $this->applyRoundingMethod(
-            $price * (1 + $taxRate / 100)
-        );
 
         return $price;
     }
@@ -157,9 +126,7 @@ class Price implements DecoratorInterface
      */
     private function calculateExchangeRate(float $price): float
     {
-        return $this->applyRoundingMethod(
-            $price * $this->exchangeRate
-        );
+        return $price * $this->exchangeRate;
     }
 
     /**

--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ https://yoursite.com/tweakwise/feed/export/key/{{feed_key}}/store/storecode //st
 - Exclude child attributes: These values of these attributes will be excluded from product data when aggregating onto the parent product.
 - Which price value will be exported as "price" to tweakwise.
 - Calculate combined prices: Set this to yes if you want to send te combined price (of all children) of an grouped/bundle product to tweakwise. Instead of the min/max price of one of the children.
-- Add the vat to prices exported. Only enable this if the prices expoted to tweakwise are missing the vat.
 
 ### Visibility settings
 Magento has multiple visibility settings, tweakwise only knows visible products meaning that if a product is in the feed then it will be visible while navigating and searching.

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -15,7 +15,7 @@
             <resource>Tweakwise_Magento2TweakwiseExport::config</resource>
             <group id="export" translate="label" type="text" sortOrder="1000" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Export</label>
-                <comment>Tweakwise Export version v7.4.1</comment>
+                <comment>Tweakwise Export version v7.5.0</comment>
                 <field id="enabled" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Enabled</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
@@ -114,15 +114,6 @@
                 <field id="calculate_composite_prices" translate="label,comment" type="select" sortOrder="110" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Calculate combined prices</label>
                     <comment>Would you like to export the combined price of an grouped/bundle product?</comment>
-                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                    <depends>
-                        <field id="enabled">1</field>
-                    </depends>
-                </field>
-
-                <field id="add_tax_to_prices" translate="label,comment" type="select" sortOrder="120" showInDefault="1" showInWebsite="1" showInStore="1">
-                    <label>Export prices incl vat</label>
-                    <comment>Add the vat to the prices exported. Only enable this if the prices exported to Tweakwise are missing the vat</comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <depends>
                         <field id="enabled">1</field>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -27,7 +27,6 @@
                 <batch_size_products>5000</batch_size_products>
                 <batch_size_products_children>5000</batch_size_products_children>
                 <calculate_composite_prices>0</calculate_composite_prices>
-                <add_tax_to_prices>0</add_tax_to_prices>
             </export>
             <export_stock>
                 <enabled>0</enabled>


### PR DESCRIPTION
When testing the new release i found two issues with the newly added export settings.

1) In #100 the method applyRoundingMethod was added. Which caused all prices exported to be rounded where they where previously not rounded. This was not intended. So i've removed the rounding method

2) In #100 an new setting was added to add vat to exported prices. This was added because the vat seemed to be missing from the new combined prices. But this was not the correct solution since it added vat to all the prices. I've removed the new add vat setting to prevent issues with other product prices.

It may still occur if the vat is missing from the combined prices. But if that is the case, it needs futher investigation and an different solution. It may be that this is caused by the vat settings.
