### PR TITLE
fix: Fix php8.4 deprecation errors

### DIFF
--- a/App/Response/FeedContent.php
+++ b/App/Response/FeedContent.php
@@ -55,7 +55,7 @@ class FeedContent
         Export $export,
         Logger $log,
         File $driver,
-        StoreInterface $store = null,
+        ?StoreInterface $store = null,
         $type = null
     ) {
         $this->export = $export;

--- a/Model/ChildOptions.php
+++ b/Model/ChildOptions.php
@@ -24,7 +24,7 @@ class ChildOptions
      * @param int|null $optionId
      * @param null $isRequired
      */
-    public function __construct(int $optionId = null, $isRequired = null)
+    public function __construct(?int $optionId = null, $isRequired = null)
     {
         $this->optionId = $optionId;
         $this->isRequired = $isRequired;

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -311,7 +311,7 @@ class Config
     /**
      * @return bool
      */
-    public function isGroupedExport(StoreInterface $store = null): bool
+    public function isGroupedExport(?StoreInterface $store = null): bool
     {
         return (bool) $this->config->getValue(
             self::PATH_GROUPED_EXPORT_ENABLED,

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -236,7 +236,7 @@ class Config
      * @throws FileSystemException
      * @throws RuntimeException
      */
-    public function getDefaultFeedFile(StoreInterface $store = null, $type = null): string
+    public function getDefaultFeedFile(?StoreInterface $store = null, ?string $type = null): string
     {
         $dir = $this->directoryList->getPath('var') . DIRECTORY_SEPARATOR . 'feeds';
         if (
@@ -274,7 +274,7 @@ class Config
      * @param string|null $file
      * @return string
      */
-    public function getFeedTmpFile($file = null, StoreInterface  $store = null): string
+    public function getFeedTmpFile(?string $file = null, ?StoreInterface  $store = null): string
     {
         if (!$file) {
             $file = $this->getDefaultFeedFile($store);

--- a/Model/Config/Source/PriceField.php
+++ b/Model/Config/Source/PriceField.php
@@ -47,7 +47,7 @@ class PriceField implements ArrayInterface
      * @return array
      * phpcs:disable Magento2.Performance.ForeachArrayMerge.ForeachArrayMerge
      */
-    protected function combineArrayPermutations(array $input, array $processed = null): array
+    protected function combineArrayPermutations(array $input, ?array $processed = null): array
     {
         $permutations = [];
         foreach ($input as $key => $value) {

--- a/Model/Export.php
+++ b/Model/Export.php
@@ -99,7 +99,7 @@ class Export
      * phpcs:disable Magento2.Functions.DiscouragedFunction.DiscouragedWithAlternative
      * @SuppressWarnings(PHPMD.ErrorControlOperator)
      */
-    protected function executeLocked(callable $action, StoreInterface $store = null, $type = null): void
+    protected function executeLocked(callable $action, ?StoreInterface $store = null, ?string $type = null): void
     {
         Profiler::start('tweakwise::export');
         $lockFile = $this->config->getFeedLockFile(null, $store, $type);
@@ -164,7 +164,7 @@ class Export
      * phpcs:disable Magento2.Functions.DiscouragedFunction.DiscouragedWithAlternative
      * @SuppressWarnings(PHPMD.ErrorControlOperator)
      */
-    public function getFeed($targetHandle, StoreInterface $store = null, $type = null): void
+    public function getFeed($targetHandle, ?StoreInterface $store = null, ?string $type = null): void
     {
         if ($this->config->isRealTime()) {
             $this->generateFeed($targetHandle, $store, $type);

--- a/Model/ProductAttributes.php
+++ b/Model/ProductAttributes.php
@@ -40,7 +40,7 @@ class ProductAttributes
      * @param string[]|null $attributeCodes
      * @return Attribute[]
      */
-    public function getAttributesToExport(array $attributeCodes = null): array
+    public function getAttributesToExport(?array $attributeCodes = null): array
     {
         try {
             $type = $this->eavConfig->getEntityType(Product::ENTITY);

--- a/Model/Scheduler.php
+++ b/Model/Scheduler.php
@@ -71,7 +71,7 @@ class Scheduler
      * @return Schedule
      * @throws Exception
      */
-    public function schedule(string $type = null): Schedule
+    public function schedule(?string $type = null): Schedule
     {
         $job = 'tweakwise_magento2_tweakwise_export';
 

--- a/Model/Write/Categories.php
+++ b/Model/Write/Categories.php
@@ -81,7 +81,7 @@ class Categories implements WriterInterface
      * @param XMLWriter $xml
      * @param StoreInterface|null $store
      */
-    public function write(Writer $writer, XMLWriter $xml, StoreInterface  $store = null): void
+    public function write(Writer $writer, XMLWriter $xml, ?StoreInterface $store = null): void
     {
         $xml->startElement('categories');
         $writer->flush();

--- a/Model/Write/Price.php
+++ b/Model/Write/Price.php
@@ -91,7 +91,7 @@ class Price implements WriterInterface
      * @param XMLWriter $xml
      * @param StoreInterface|null $store
      */
-    public function write(Writer $writer, XMLWriter $xml, StoreInterface  $store = null): void
+    public function write(Writer $writer, XMLWriter $xml, ?StoreInterface $store = null): void
     {
         $xml->startElement('items');
 

--- a/Model/Write/Price/ExportEntityFactory.php
+++ b/Model/Write/Price/ExportEntityFactory.php
@@ -74,7 +74,7 @@ class ExportEntityFactory
      * @param string $typeId
      * @return string
      */
-    protected function getInstanceType(string $typeId = null): string
+    protected function getInstanceType(?string $typeId = null): string
     {
         return $this->typeMap[$typeId] ?? $this->getDefaultType($typeId);
     }

--- a/Model/Write/Products.php
+++ b/Model/Write/Products.php
@@ -91,7 +91,7 @@ class Products implements WriterInterface
      * @param XMLWriter $xml
      * @param StoreInterface|null $store
      */
-    public function write(Writer $writer, XMLWriter $xml, StoreInterface  $store = null): void
+    public function write(Writer $writer, XMLWriter $xml, ?StoreInterface $store = null): void
     {
         $xml->startElement('items');
 

--- a/Model/Write/Products/CollectionDecorator/Children.php
+++ b/Model/Write/Products/CollectionDecorator/Children.php
@@ -303,7 +303,7 @@ class Children implements DecoratorInterface
         Collection|StockCollection|PriceCollection $collection,
         int $parentId,
         int $childId,
-        ChildOptions $childOptions = null
+        ?ChildOptions $childOptions = null
     ): void {
         if (!$this->childEntities->has($childId)) {
             $child = $this->entityChildFactory->createChild(

--- a/Model/Write/Products/ExportEntityFactory.php
+++ b/Model/Write/Products/ExportEntityFactory.php
@@ -74,7 +74,7 @@ class ExportEntityFactory
      * @param string $typeId
      * @return string
      */
-    protected function getInstanceType(string $typeId = null): string
+    protected function getInstanceType(?string $typeId = null): string
     {
         return $this->typeMap[$typeId] ?? $this->getDefaultType($typeId);
     }

--- a/Model/Write/Stock.php
+++ b/Model/Write/Stock.php
@@ -91,7 +91,7 @@ class Stock implements WriterInterface
      * @param XMLWriter $xml
      * @param StoreInterface|null $store
      */
-    public function write(Writer $writer, XMLWriter $xml, StoreInterface  $store = null): void
+    public function write(Writer $writer, XMLWriter $xml, ?StoreInterface $store = null): void
     {
         $xml->startElement('items');
 

--- a/Model/Write/Stock/ExportEntityFactory.php
+++ b/Model/Write/Stock/ExportEntityFactory.php
@@ -74,7 +74,7 @@ class ExportEntityFactory
      * @param string $typeId
      * @return string
      */
-    protected function getInstanceType(string $typeId = null): string
+    protected function getInstanceType(?string $typeId = null): string
     {
         return $this->typeMap[$typeId] ?? $this->getDefaultType($typeId);
     }

--- a/Model/Write/Writer.php
+++ b/Model/Write/Writer.php
@@ -129,7 +129,7 @@ class Writer
      * @param resource $resource
      * @param null|StoreInterface $store
      */
-    public function write($resource, StoreInterface $store = null, $type = null): void
+    public function write($resource, ?StoreInterface $store = null, ?string $type = null): void
     {
         try {
             Profiler::start('write');
@@ -200,7 +200,7 @@ class Writer
         }
     }
 
-    protected function startDocumentType(StoreInterface $store = null, $type = null)
+    protected function startDocumentType(?StoreInterface $store = null, ?string $type = null)
     {
         if ($type === 'stock' || $type === 'price') {
             $this->startExternalDocument();
@@ -212,7 +212,7 @@ class Writer
     /**
      * Write document start
      */
-    protected function startDocument(StoreInterface $store = null): void
+    protected function startDocument(?StoreInterface $store = null): void
     {
         if ($store === null) {
             $store = $this->storeManager->getDefaultStoreView();

--- a/Profiler/Driver/ConsoleDriver.php
+++ b/Profiler/Driver/ConsoleDriver.php
@@ -40,7 +40,7 @@ class ConsoleDriver implements DriverInterface
     /**
      * {@inheritdoc}
      */
-    public function start($timerId, array $tags = null)
+    public function start($timerId, ?array $tags = null)
     {
         $this->stat->start($timerId, microtime(true), memory_get_usage(true), memory_get_usage());
         $this->display($timerId);

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -16,7 +16,7 @@
     <type name="Magento\Framework\Console\CommandListInterface">
         <arguments>
             <argument name="commands" xsi:type="array">
-                <item name="TweakwiseMagento2TweakwiseExportCommand" xsi:type="object">Tweakwise\Magento2TweakwiseExport\Console\Command\ExportCommand\Proxy</item>
+                <item name="TweakwiseMagento2TweakwiseExportCommand" xsi:type="object">Tweakwise\Magento2TweakwiseExport\Console\Command\ExportCommand</item>
             </argument>
         </arguments>
     </type>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -16,7 +16,7 @@
     <type name="Magento\Framework\Console\CommandListInterface">
         <arguments>
             <argument name="commands" xsi:type="array">
-                <item name="TweakwiseMagento2TweakwiseExportCommand" xsi:type="object">Tweakwise\Magento2TweakwiseExport\Console\Command\ExportCommand</item>
+                <item name="TweakwiseMagento2TweakwiseExportCommand" xsi:type="object">Tweakwise\Magento2TweakwiseExport\Console\Command\ExportCommand\Proxy</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
Fix php 8.4 deprecation errors -

Implicitly marking parameter $store as nullable is deprecated, the explicit nullable type must be used instead