### PR TITLE
Feat: grouped export

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -309,8 +309,8 @@ class Config
     /**
      * @return bool
      */
-    public function isGroupedExport(): bool
+    public function isGroupedExport(StoreInterface $store = null): bool
     {
-        return (bool) $this->config->getValue('tweakwise/export/grouped_export_enabled');
+        return (bool) $this->config->getValue('tweakwise/export/grouped_export_enabled', ScopeInterface::SCOPE_STORE, $store);
     }
 }

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -41,6 +41,7 @@ class Config
     public const BATCH_SIZE_PRODUCTS_CHILDREN = 'tweakwise/export/batch_size_products_children';
     public const PATH_SKIP_CHILD_BY_COMPOSITE_TYPE = 'tweakwise/export/skip_child_by_composite_type';
     public const CALCULATE_COMPOSITE_PRICES = 'tweakwise/export/calculate_composite_prices';
+    public const PATH_GROUPED_EXPORT_ENABLED = 'tweakwise/export/grouped_export_enabled';
 
     /**
      * Default feed filename
@@ -313,7 +314,7 @@ class Config
     public function isGroupedExport(StoreInterface $store = null): bool
     {
         return (bool) $this->config->getValue(
-            'tweakwise/export/grouped_export_enabled',
+            self::PATH_GROUPED_EXPORT_ENABLED,
             ScopeInterface::SCOPE_STORE,
             $store
         );

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -313,7 +313,8 @@ class Config
     {
         return (bool) $this->config->getValue(
             'tweakwise/export/grouped_export_enabled',
-            ScopeInterface::SCOPE_STORE, $store
+            ScopeInterface::SCOPE_STORE,
+            $store
         );
     }
 }

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -305,4 +305,12 @@ class Config
     {
         return (int) $this->config->getValue(self::BATCH_SIZE_PRODUCTS_CHILDREN);
     }
+
+    /**
+     * @return bool
+     */
+    public function isGroupedExport(): bool
+    {
+        return (bool) $this->config->getValue('tweakwise/export/grouped_export_enabled');
+    }
 }

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -318,8 +318,8 @@ class Config
             $store
         );
     }
-  
-    /**  
+
+    /**
      * @param Store $store
      * @return bool
      */

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -311,6 +311,9 @@ class Config
      */
     public function isGroupedExport(StoreInterface $store = null): bool
     {
-        return (bool) $this->config->getValue('tweakwise/export/grouped_export_enabled', ScopeInterface::SCOPE_STORE, $store);
+        return (bool) $this->config->getValue(
+            'tweakwise/export/grouped_export_enabled',
+            ScopeInterface::SCOPE_STORE, $store
+        );
     }
 }

--- a/Model/Write/Categories/Iterator.php
+++ b/Model/Write/Categories/Iterator.php
@@ -60,6 +60,7 @@ class Iterator extends EavIterator
             $eavConfig,
             $dbContext,
             $eventManager,
+            $config,
             'catalog_category',
             $attributes,
             $config->getBatchSizeCategories()

--- a/Model/Write/EavIterator.php
+++ b/Model/Write/EavIterator.php
@@ -274,7 +274,7 @@ class EavIterator implements IteratorAggregate
             try {
                 Profiler::start('eav-iterator::' . $this->entityCode);
                 $this->setEntityIds($entityIds);
-                if ($this->config->isGroupedExport($this->store) && $this->entityCode === 'catalog_product') {
+                if ($this->config->isGroupedExport($this->store) && $this->entityCode === Product::ENTITY) {
                     $this->preloadParentRelations($entityIds);
                 }
 

--- a/Model/Write/EavIterator.php
+++ b/Model/Write/EavIterator.php
@@ -10,6 +10,7 @@
 namespace Tweakwise\Magento2TweakwiseExport\Model\Write;
 
 // phpcs:disable Magento2.Legacy.RestrictedCode.ZendDbSelect
+use Magento\Catalog\Model\Product;
 use Tweakwise\Magento2TweakwiseExport\Exception\InvalidArgumentException;
 use Tweakwise\Magento2TweakwiseExport\Model\Helper;
 use IteratorAggregate;
@@ -298,7 +299,7 @@ class EavIterator implements IteratorAggregate
                         $result = array_merge($result, $this->entityData[$result['entity_id']]);
                         if (
                             $this->config->isGroupedExport($this->store) &&
-                            $this->entityCode === 'catalog_product' &&
+                            $this->entityCode === Product::ENTITY &&
                             isset($this->parentRelations[$result['entity_id']])
                         ) {
                             $result['parent_id'] = $this->parentRelations[$result['entity_id']];

--- a/Model/Write/EavIterator.php
+++ b/Model/Write/EavIterator.php
@@ -106,7 +106,9 @@ class EavIterator implements IteratorAggregate
      */
     protected $entityData = [];
 
-
+    /**
+     * @var array $parentRelations
+     */
     private array $parentRelations = [];
 
     /**
@@ -116,6 +118,7 @@ class EavIterator implements IteratorAggregate
      * @param EavConfig $eavConfig
      * @param DbContext $dbContext
      * @param Manager $eventManager
+     * @param Config $config
      * @param string $entityCode
      * @param string[] $attributes
      * @param int $batchSize
@@ -291,11 +294,14 @@ class EavIterator implements IteratorAggregate
                     // Loop over all rows and combine them to one array for entity
                     foreach ($this->loopUnionRows($stmt) as $result) {
                         $result = array_merge($result, $this->entityData[$result['entity_id']]);
-                        if ($this->config->isGroupedExport($this->store) && $this->entityCode === 'catalog_product') {
-                            if (isset($this->parentRelations[$result['entity_id']])) {
-                                $result['parent_id'] = $this->parentRelations[$result['entity_id']];
-                            }
+                        if (
+                            $this->config->isGroupedExport($this->store) &&
+                            $this->entityCode === 'catalog_product' &&
+                            isset($this->parentRelations[$result['entity_id']])
+                        ) {
+                            $result['parent_id'] = $this->parentRelations[$result['entity_id']];
                         }
+
                         yield $result;
                     }
                 } finally {

--- a/Model/Write/EavIterator.php
+++ b/Model/Write/EavIterator.php
@@ -27,6 +27,7 @@ use Magento\Framework\Profiler;
 use Magento\Store\Model\Store;
 use Zend_Db_Expr;
 use Zend_Db_Select;
+use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
 
 /**
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
@@ -275,6 +276,7 @@ class EavIterator implements IteratorAggregate
                 if ($this->config->isGroupedExport($this->store) && $this->entityCode === 'catalog_product') {
                     $this->preloadParentRelations($entityIds);
                 }
+
                 $select = $this->createSelect();
 
                 Profiler::start('query');
@@ -569,7 +571,7 @@ class EavIterator implements IteratorAggregate
                 [] // We don't need additional columns, just filtering
             )
             ->where('cpsl.product_id IN (?)', $productIds)
-            ->where('cpe.type_id = ?', \Magento\ConfigurableProduct\Model\Product\Type\Configurable::TYPE_CODE);
+            ->where('cpe.type_id = ?', Configurable::TYPE_CODE);
 
         $this->parentRelations = $connection->fetchPairs($select);
     }

--- a/Model/Write/Price/Iterator.php
+++ b/Model/Write/Price/Iterator.php
@@ -66,6 +66,7 @@ class Iterator extends EavIterator
             $eavConfig,
             $dbContext,
             $eventManager,
+            $config,
             Product::ENTITY,
             [],
             $config->getBatchSizeProducts()

--- a/Model/Write/Products.php
+++ b/Model/Write/Products.php
@@ -104,6 +104,9 @@ class Products implements WriterInterface
 
         /** @var Store $store */
         foreach ($stores as $store) {
+            if($store->getId() !== '1') {
+                continue;
+            }
             if ($this->config->isEnabled($store)) {
                 $profileKey = 'products::' . $store->getCode();
                 try {
@@ -162,6 +165,7 @@ class Products implements WriterInterface
         $xml->writeElement('name', $this->scalarValue($data['name']));
         $xml->writeElement('price', $this->scalarValue($data['price']));
         $xml->writeElement('stock', $this->scalarValue($data['stock']));
+        $xml->writeElement('groupcode', $this->scalarValue($data['groupcode']));
 
         // Write product categories
         $xml->startElement('categories');

--- a/Model/Write/Products.php
+++ b/Model/Write/Products.php
@@ -162,7 +162,10 @@ class Products implements WriterInterface
         $xml->writeElement('name', $this->scalarValue($data['name']));
         $xml->writeElement('price', $this->scalarValue($data['price']));
         $xml->writeElement('stock', $this->scalarValue($data['stock']));
-        $xml->writeElement('groupcode', $this->scalarValue($data['groupcode']));
+
+        if ($this->config->isGroupedExport($this->storeManager->getStore($storeId))) {
+            $xml->writeElement('groupcode', $this->scalarValue($data['groupcode']));
+        }
 
         // Write product categories
         $xml->startElement('categories');

--- a/Model/Write/Products.php
+++ b/Model/Write/Products.php
@@ -104,9 +104,6 @@ class Products implements WriterInterface
 
         /** @var Store $store */
         foreach ($stores as $store) {
-            if($store->getId() !== '1') {
-                continue;
-            }
             if ($this->config->isEnabled($store)) {
                 $profileKey = 'products::' . $store->getCode();
                 try {

--- a/Model/Write/Products/CollectionDecorator/Children.php
+++ b/Model/Write/Products/CollectionDecorator/Children.php
@@ -338,7 +338,6 @@ class Children implements DecoratorInterface
                     $childEntity->addCategoryId($category);
                 }
             }
-
         } catch (InvalidArgumentException $exception) {
             // no implementation, parent was not found
         }

--- a/Model/Write/Products/CollectionDecorator/Children.php
+++ b/Model/Write/Products/CollectionDecorator/Children.php
@@ -332,10 +332,18 @@ class Children implements DecoratorInterface
             if ($this->config->isGroupedExport($collection->getStore())) {
                 $childEntity = $collection->get($childId);
                 $childEntity->setGroupCode($parentId);
-                $childEntity->addAttribute('parent_url_key',
-                    $parent->getAttribute('url_key', false));
-                $childEntity->addAttribute('parent_name',
-                    $parent->getAttribute('name', false));
+                $childEntity->addAttribute(
+                    'parent_url_key',
+                    $parent->getAttribute('url_key', false)
+                );
+                $childEntity->addAttribute(
+                    'parent_name',
+                    $parent->getAttribute('name', false)
+                );
+                $childEntity->addAttribute(
+                    'parent_visibility',
+                    $parent->getAttribute('visibility', false)
+                );
 
                 if ($childEntity->getCategories() === []) {
                     $categories = $parent->getCategories();

--- a/Model/Write/Products/CollectionDecorator/Children.php
+++ b/Model/Write/Products/CollectionDecorator/Children.php
@@ -93,7 +93,7 @@ class Children implements DecoratorInterface
         CollectionFactory $collectionFactory,
         Helper $helper,
         DbResourceHelper $dbResource,
-        TweakwiseConfig $config,
+        private readonly TweakwiseConfig $config,
         private readonly WebsiteLink $websiteLink
     ) {
         $this->productType = $productType;
@@ -329,13 +329,19 @@ class Children implements DecoratorInterface
                 $parent->addChild($child);
             }
 
-            $childEntity = $collection->get($childId);
-            $childEntity->setGroupCode($parentId);
+            if ($this->config->isGroupedExport($collection->getStore())) {
+                $childEntity = $collection->get($childId);
+                $childEntity->setGroupCode($parentId);
+                $childEntity->addAttribute('parent_url_key',
+                    $parent->getAttribute('url_key', false));
+                $childEntity->addAttribute('parent_name',
+                    $parent->getAttribute('name', false));
 
-            if ($childEntity->getCategories() === []) {
-                $categories = $parent->getCategories();
-                foreach ($categories as $category) {
-                    $childEntity->addCategoryId($category);
+                if ($childEntity->getCategories() === []) {
+                    $categories = $parent->getCategories();
+                    foreach ($categories as $category) {
+                        $childEntity->addCategoryId($category);
+                    }
                 }
             }
         } catch (InvalidArgumentException $exception) {

--- a/Model/Write/Products/CollectionDecorator/Children.php
+++ b/Model/Write/Products/CollectionDecorator/Children.php
@@ -305,6 +305,7 @@ class Children implements DecoratorInterface
         int $childId,
         ChildOptions $childOptions = null
     ): void {
+
         if (!$this->childEntities->has($childId)) {
             $child = $this->entityChildFactory->createChild(
                 [
@@ -327,6 +328,10 @@ class Children implements DecoratorInterface
             if ($parent instanceof CompositeExportEntityInterface) {
                 $parent->addChild($child);
             }
+
+            $childEntity = $collection->get($childId);
+            $childEntity->setGroupCode($parentId);
+
         } catch (InvalidArgumentException $exception) {
             // no implementation, parent was not found
         }

--- a/Model/Write/Products/CollectionDecorator/Children.php
+++ b/Model/Write/Products/CollectionDecorator/Children.php
@@ -332,6 +332,13 @@ class Children implements DecoratorInterface
             $childEntity = $collection->get($childId);
             $childEntity->setGroupCode($parentId);
 
+            if ($childEntity->getCategories() === []) {
+                $categories = $parent->getCategories();
+                foreach ($categories as $category) {
+                    $childEntity->addCategoryId($category);
+                }
+            }
+
         } catch (InvalidArgumentException $exception) {
             // no implementation, parent was not found
         }

--- a/Model/Write/Products/ExportEntity.php
+++ b/Model/Write/Products/ExportEntity.php
@@ -425,7 +425,7 @@ class ExportEntity
         if ($this->config->isGroupedExport($this->store)) {
             return true;
         }
-        
+
         return \in_array($this->getVisibility(), $this->visibilityObject->getVisibleInSiteIds(), true);
     }
 

--- a/Model/Write/Products/ExportEntity.php
+++ b/Model/Write/Products/ExportEntity.php
@@ -423,7 +423,15 @@ class ExportEntity
     protected function shouldExportByVisibility(): bool
     {
         if ($this->config->isGroupedExport($this->store)) {
-            return true;
+            // Check if the simple product has a parent (belongs to a configurable)
+            if ($this->getTypeId() === \Magento\Catalog\Model\Product\Type::TYPE_SIMPLE) {
+                try{
+                    $this->getAttribute('parent_id');
+                    return true;
+                } catch (InvalidArgumentException $e) {
+                    return \in_array($this->getVisibility(), $this->visibilityObject->getVisibleInSiteIds(), true);
+                }
+            }
         }
 
         return \in_array($this->getVisibility(), $this->visibilityObject->getVisibleInSiteIds(), true);

--- a/Model/Write/Products/ExportEntity.php
+++ b/Model/Write/Products/ExportEntity.php
@@ -99,6 +99,8 @@ class ExportEntity
      * @param StoreManagerInterface $storeManager
      * @param StockConfigurationInterface $stockConfiguration
      * @param Visibility $visibility
+     * @param Config $config
+     * @param Helper $helper
      * @param array $data
      */
     public function __construct(
@@ -254,6 +256,9 @@ class ExportEntity
         return $this->helper->getTweakwiseId($this->getStore()->getId(), $this->getId());
     }
 
+    /**
+     * @param int $groupCode
+     */
     public function setGroupCode(int $groupCode): void
     {
         $this->groupCode = $groupCode;
@@ -417,7 +422,7 @@ class ExportEntity
      */
     protected function shouldExportByVisibility(): bool
     {
-        if ($this->config->isGroupedExport()) {
+        if ($this->config->isGroupedExport($this->store)) {
             return true;
         }
         return \in_array($this->getVisibility(), $this->visibilityObject->getVisibleInSiteIds(), true);

--- a/Model/Write/Products/ExportEntity.php
+++ b/Model/Write/Products/ExportEntity.php
@@ -3,12 +3,14 @@
 namespace Tweakwise\Magento2TweakwiseExport\Model\Write\Products;
 
 use Tweakwise\Magento2TweakwiseExport\Exception\InvalidArgumentException;
+use Tweakwise\Magento2TweakwiseExport\Model\Helper;
 use Tweakwise\Magento2TweakwiseExport\Model\StockItem;
 use Magento\Catalog\Model\Product\Attribute\Source\Status;
 use Magento\Catalog\Model\Product\Visibility;
 use Magento\CatalogInventory\Api\StockConfigurationInterface;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\Store\Model\Store;
+use Tweakwise\Magento2TweakwiseExport\Model\Config;
 
 /**
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
@@ -99,6 +101,8 @@ class ExportEntity
         StoreManagerInterface $storeManager,
         StockConfigurationInterface $stockConfiguration,
         Visibility $visibility,
+        private readonly Config $config,
+        private readonly Helper $helper,
         array $data = []
     ) {
         $this->setFromArray($data);
@@ -231,6 +235,18 @@ class ExportEntity
     public function getStockQty(): float
     {
         return (float) ($this->getStockItem() ? $this->getStockItem()->getQty() : 0);
+    }
+
+    /**
+     * @return string
+     */
+    public function getGroupCode(): string
+    {
+        if ($this->typeId === 'simple') {
+            //return $this->getParentSku();
+        }
+
+        return $this->helper->getTweakwiseId($this->getStore()->getId(), $this->getId());
     }
 
     /**
@@ -391,6 +407,9 @@ class ExportEntity
      */
     protected function shouldExportByVisibility(): bool
     {
+        if ($this->config->isGroupedExport()) {
+            return true;
+        }
         return \in_array($this->getVisibility(), $this->visibilityObject->getVisibleInSiteIds(), true);
     }
 

--- a/Model/Write/Products/ExportEntity.php
+++ b/Model/Write/Products/ExportEntity.php
@@ -63,6 +63,11 @@ class ExportEntity
     protected $price = 0.0;
 
     /**
+     * @var int
+     */
+    protected $groupCode = 0;
+
+    /**
      * @var StockItem
      */
     protected $stockItem;
@@ -142,6 +147,8 @@ class ExportEntity
                     $this->setPrice((float) $value);
                     $this->addAttribute($key, (float) $value);
                     break;
+                case 'groupCode':
+                    $this->setGroupCode((int) $value);
                 default:
                     $this->addAttribute($key, $value);
                     break;
@@ -238,15 +245,20 @@ class ExportEntity
     }
 
     /**
-     * @return string
+     * @return int
      */
-    public function getGroupCode(): string
+    public function getGroupCode(): int
     {
         if ($this->typeId === 'simple') {
-            //return $this->getParentSku();
+            return $this->helper->getTweakwiseId($this->getStore()->getId(), $this->groupCode);
         }
 
         return $this->helper->getTweakwiseId($this->getStore()->getId(), $this->getId());
+    }
+
+    public function setGroupCode(int $groupCode): void
+    {
+        $this->groupCode = $groupCode;
     }
 
     /**

--- a/Model/Write/Products/ExportEntity.php
+++ b/Model/Write/Products/ExportEntity.php
@@ -425,6 +425,7 @@ class ExportEntity
         if ($this->config->isGroupedExport($this->store)) {
             return true;
         }
+        
         return \in_array($this->getVisibility(), $this->visibilityObject->getVisibleInSiteIds(), true);
     }
 

--- a/Model/Write/Products/ExportEntity.php
+++ b/Model/Write/Products/ExportEntity.php
@@ -425,7 +425,7 @@ class ExportEntity
         if ($this->config->isGroupedExport($this->store)) {
             // Check if the simple product has a parent (belongs to a configurable)
             if ($this->getTypeId() === \Magento\Catalog\Model\Product\Type::TYPE_SIMPLE) {
-                try{
+                try {
                     $this->getAttribute('parent_id');
                     return true;
                 } catch (InvalidArgumentException $e) {

--- a/Model/Write/Products/ExportEntity.php
+++ b/Model/Write/Products/ExportEntity.php
@@ -11,6 +11,7 @@ use Magento\CatalogInventory\Api\StockConfigurationInterface;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\Store\Model\Store;
 use Tweakwise\Magento2TweakwiseExport\Model\Config;
+use Magento\Catalog\Model\Product\Type;
 
 /**
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
@@ -424,7 +425,7 @@ class ExportEntity
     {
         if ($this->config->isGroupedExport($this->store)) {
             // Check if the simple product has a parent (belongs to a configurable)
-            if ($this->getTypeId() === \Magento\Catalog\Model\Product\Type::TYPE_SIMPLE) {
+            if ($this->getTypeId() === Type::TYPE_SIMPLE) {
                 try {
                     $this->getAttribute('parent_id');
                     return true;

--- a/Model/Write/Products/ExportEntity.php
+++ b/Model/Write/Products/ExportEntity.php
@@ -430,7 +430,7 @@ class ExportEntity
                     $this->getAttribute('parent_id');
                     return true;
                 } catch (InvalidArgumentException $e) {
-                    return \in_array($this->getVisibility(), $this->visibilityObject->getVisibleInSiteIds(), true);
+                    return in_array($this->getVisibility(), $this->visibilityObject->getVisibleInSiteIds(), true);
                 }
             }
         }

--- a/Model/Write/Products/ExportEntity.php
+++ b/Model/Write/Products/ExportEntity.php
@@ -250,11 +250,7 @@ class ExportEntity
      */
     public function getGroupCode(): int
     {
-        if ($this->groupCode) {
-            return $this->helper->getTweakwiseId($this->getStore()->getId(), $this->groupCode);
-        }
-
-        return $this->helper->getTweakwiseId($this->getStore()->getId(), $this->getId());
+        return $this->helper->getTweakwiseId($this->getStore()->getId(), $this->groupCode ?? $this->getId());
     }
 
     /**

--- a/Model/Write/Products/ExportEntity.php
+++ b/Model/Write/Products/ExportEntity.php
@@ -147,8 +147,6 @@ class ExportEntity
                     $this->setPrice((float) $value);
                     $this->addAttribute($key, (float) $value);
                     break;
-                case 'groupCode':
-                    $this->setGroupCode((int) $value);
                 default:
                     $this->addAttribute($key, $value);
                     break;
@@ -249,7 +247,7 @@ class ExportEntity
      */
     public function getGroupCode(): int
     {
-        if ($this->typeId === 'simple') {
+        if ($this->groupCode) {
             return $this->helper->getTweakwiseId($this->getStore()->getId(), $this->groupCode);
         }
 

--- a/Model/Write/Products/ExportEntityChild.php
+++ b/Model/Write/Products/ExportEntityChild.php
@@ -34,6 +34,7 @@ class ExportEntityChild extends ExportEntity
      * @param StoreManagerInterface $storeManager
      * @param StockConfigurationInterface $stockConfiguration
      * @param Visibility $visibility
+     * @param Helper $helper
      * @param array $data
      */
     public function __construct(
@@ -94,10 +95,5 @@ class ExportEntityChild extends ExportEntity
         }
 
         return $this->isInStock();
-    }
-
-    public function setParentId($parentId): void
-    {
-        $this->parentId = $parentId;
     }
 }

--- a/Model/Write/Products/ExportEntityChild.php
+++ b/Model/Write/Products/ExportEntityChild.php
@@ -18,11 +18,6 @@ class ExportEntityChild extends ExportEntity
     protected $childOptions;
 
     /**
-     * @var int
-     */
-    private int $parentId;
-
-    /**
      * @var Config
      */
     protected $config;

--- a/Model/Write/Products/ExportEntityChild.php
+++ b/Model/Write/Products/ExportEntityChild.php
@@ -8,6 +8,7 @@ use Magento\Catalog\Model\Product\Visibility;
 use Magento\CatalogInventory\Api\StockConfigurationInterface;
 use Magento\Store\Model\Store;
 use Magento\Store\Model\StoreManagerInterface;
+use Tweakwise\Magento2TweakwiseExport\Model\Helper;
 
 class ExportEntityChild extends ExportEntity
 {
@@ -15,6 +16,11 @@ class ExportEntityChild extends ExportEntity
      * @var ChildOptions
      */
     protected $childOptions;
+
+    /**
+     * @var int
+     */
+    private int $parentId;
 
     /**
      * @var Config
@@ -36,6 +42,7 @@ class ExportEntityChild extends ExportEntity
         StoreManagerInterface $storeManager,
         StockConfigurationInterface $stockConfiguration,
         Visibility $visibility,
+        private readonly Helper $helper,
         array $data = []
     ) {
         parent::__construct(
@@ -43,6 +50,8 @@ class ExportEntityChild extends ExportEntity
             $storeManager,
             $stockConfiguration,
             $visibility,
+            $config,
+            $helper,
             $data
         );
 
@@ -85,5 +94,10 @@ class ExportEntityChild extends ExportEntity
         }
 
         return $this->isInStock();
+    }
+
+    public function setParentId($parentId): void
+    {
+        $this->parentId = $parentId;
     }
 }

--- a/Model/Write/Products/Iterator.php
+++ b/Model/Write/Products/Iterator.php
@@ -18,6 +18,7 @@ use Magento\Eav\Model\Config as EavConfig;
 use Magento\Framework\Event\Manager;
 use Magento\Framework\Model\ResourceModel\Db\Context as DbContext;
 use Tweakwise\Magento2TweakwiseExport\Model\Config as TweakwiseConfig;
+use Tweakwise\Magento2TweakwiseExport\Model\Write\Products\ExportEntityConfigurable;
 
 class Iterator extends EavIterator
 {
@@ -65,6 +66,7 @@ class Iterator extends EavIterator
             $eavConfig,
             $dbContext,
             $eventManager,
+            $config,
             Product::ENTITY,
             [],
             $config->getBatchSizeProducts()
@@ -83,6 +85,8 @@ class Iterator extends EavIterator
     public function getIterator(): \Traversable
     {
         $batch = $this->collectionFactory->create(['store' => $this->store]);
+        $entityIds = [];
+
         foreach (parent::getIterator() as $entityData) {
             $entity = $this->entityFactory->create(
                 [
@@ -126,7 +130,7 @@ class Iterator extends EavIterator
         }
 
         foreach ($collection->getExported() as $entity) {
-            if ($this->config->isGroupedExport($this->store) && $entity instanceof CompositeExportEntityInterface) {
+            if ($this->config->isGroupedExport($this->store) && $entity instanceof ExportEntityConfigurable) {
                 continue;
             }
 
@@ -141,4 +145,5 @@ class Iterator extends EavIterator
             ];
         }
     }
+
 }

--- a/Model/Write/Products/Iterator.php
+++ b/Model/Write/Products/Iterator.php
@@ -58,7 +58,7 @@ class Iterator extends EavIterator
         CollectionFactory $collectionFactory,
         IteratorInitializer $iteratorInitializer,
         array $collectionDecorators,
-        TweakwiseConfig $config
+        private readonly TweakwiseConfig $config
     ) {
         parent::__construct(
             $helper,
@@ -126,6 +126,10 @@ class Iterator extends EavIterator
         }
 
         foreach ($collection->getExported() as $entity) {
+
+            if ($this->config->isGroupedExport() && $entity instanceof CompositeExportEntityInterface) {
+                continue;
+            }
 
             yield [
                 'entity_id' => $entity->getId(),

--- a/Model/Write/Products/Iterator.php
+++ b/Model/Write/Products/Iterator.php
@@ -126,8 +126,7 @@ class Iterator extends EavIterator
         }
 
         foreach ($collection->getExported() as $entity) {
-
-            if ($this->config->isGroupedExport() && $entity instanceof CompositeExportEntityInterface) {
+            if ($this->config->isGroupedExport($this->store) && $entity instanceof CompositeExportEntityInterface) {
                 continue;
             }
 

--- a/Model/Write/Products/Iterator.php
+++ b/Model/Write/Products/Iterator.php
@@ -90,6 +90,7 @@ class Iterator extends EavIterator
                     'data' => $entityData
                 ]
             );
+
             if (!$entity->shouldProcess()) {
                 continue;
             }
@@ -125,11 +126,13 @@ class Iterator extends EavIterator
         }
 
         foreach ($collection->getExported() as $entity) {
+
             yield [
                 'entity_id' => $entity->getId(),
                 'name' => $entity->getName(),
                 'price' => $entity->getPrice(),
                 'stock' => (int) round($entity->getStockQty()),
+                'groupcode' => $entity->getGroupCode(),
                 'categories' => $entity->getCategories(),
                 'attributes' => $entity->getAttributes(),
             ];

--- a/Model/Write/Products/Iterator.php
+++ b/Model/Write/Products/Iterator.php
@@ -145,5 +145,4 @@ class Iterator extends EavIterator
             ];
         }
     }
-
 }

--- a/Model/Write/Products/Iterator.php
+++ b/Model/Write/Products/Iterator.php
@@ -85,7 +85,6 @@ class Iterator extends EavIterator
     public function getIterator(): \Traversable
     {
         $batch = $this->collectionFactory->create(['store' => $this->store]);
-        $entityIds = [];
 
         foreach (parent::getIterator() as $entityData) {
             $entity = $this->entityFactory->create(

--- a/Model/Write/Stock/Iterator.php
+++ b/Model/Write/Stock/Iterator.php
@@ -66,6 +66,7 @@ class Iterator extends EavIterator
             $eavConfig,
             $dbContext,
             $eventManager,
+            $config,
             Product::ENTITY,
             [],
             $config->getBatchSizeProducts()

--- a/README.md
+++ b/README.md
@@ -68,6 +68,18 @@ The feed contains only attributes which have bearing on search or navigation, ch
 
 The feed prices are exported in the default configured currency of the store (from v5.1.0 forward). If an exchange rate is available the prices for that currency are calculated. If no exchange rate is available, the original prices are used.
 
+## Grouped export
+If you have groupcode enabled all products are exported with their groupcode. All variants of a product (configurable, grouped, bundle) are linked together using the groupcode. If this is enabled all variants are separated products in Tweakwise. Use this if you want to filter out products based on variant data.
+If you switch from to normal export to groupcode export, you will need to do the following:
+1. Enable groupcode export in the configuration.
+2. Run the tweakwise:export command to generate the feed.
+3. Make sure the image urls are correct in Tweakwise.
+4. Import the feed into Tweakwise and publish the catalog.
+5. Enable Stores->configuration->catalog->tweakwise->general->Grouped products
+6. Clear the cache
+
+During the switch the catalog may be empty. If the image url are not correct no product images may be shown in magento. Please contact support if you have issues with this.
+
 ## A note on the feed implementation
 Magento's native interfaces and handlers for data retrieval were deemed to slow for a large catalog.
 Since performance is essential we decided on our own queries for data retrieval. The consequence is that we need to keep track of the inner workings of magento and are subject to its changes.
@@ -80,17 +92,42 @@ https://yoursite.com/tweakwise/feed/export/key/{{feed_key}}/type/price //price e
 https://yoursite.com/tweakwise/feed/export/key/{{feed_key}}/store/storecode //store level export, only available if store level export is enabled
 
 ## Export Settings
-- Store Level Export: Enables generating seperate feed for each store. If store level export is enabled.
-- Enabled: If products of that store should be exported to tweakwise, note that if this is false for some store then navigation and search should also be disabled for that store.
-- Schedule: Cron schedule for generating the feed. We strongly encourage you to register the export task on the server crontab instead of using the Magento cron.
-- Schedule export: Generate the feed on the next cron run. (default feed)
-- Key: This will be validated by the export module when the ExportController is asked for feed content or when the CacheFlush controller is asked to flush cache. If the request does not have a key parameter that matches the feed will not be served (or in case of the cache controller the cache will not be flushed).
-- Allow cache flush: Allow automated flushing of cache, you can configure a task in the navigator to run after it is done publishing to flush Magento caches. You must specify an url in the task configuration: use https://yoursite.com/tweakwise/cache/flush/key/{{feed_key}} as its url, here feed_key is equal to the key configured in the Key setting (see above). If this setting is set to no tweakwise-export will ignore these requests. 
-- Export realtime: When the ExportController is asked for a feed it will generate a new one on the fly. Note that this is not recommended!
-- Tweakwise import API url: Tasks in the navigator can be executed via API. Use the import task API url here to automatically tell tweakwise to import the feed after it has been generated. An seperate trigger for stock/price export can be used.
-- Export out of stock Combined product children: Tweakwise export aggregates child data on parent products, this setting determines if data from out of child products should be included in this aggregation.
-- Exclude child attributes: These values of these attributes will be excluded from product data when aggregating onto the parent product.
-- Which price value will be exported as "price" to tweakwise.
+
+All export settings can be found under Stores -> Configuration -> Catalog -> Tweakwise -> Export.
+
+- **Enabled**: If products of that store should be exported to Tweakwise. If disabled, navigation and search should also be disabled for that store.
+- **Store Level Export**: Enables generating separate feeds for each store. If enabled, feeds are generated per store.
+- **Use groupcode for export**: Use groupcode for product export.
+- **Key**: Used to validate feed and cache flush requests. The feed will only be served if the request contains the correct key.
+- **Allow cache flush**: Allows automated cache flush via a specific URL. Used for post-publish cache clearing.
+- **Validate**: Validates export on product, category, and product-category link count.
+- **Archive**: Number of feeds to keep in archive.
+- **Export in Real Time**: Always export the feed in real time when requested. Not recommended for production.
+- **Tweakwise Import API Url**: API trigger URL to start import in Tweakwise after feed generation.
+- **Export out of stock combined product children**: Export out-of-stock child attributes in parent products.
+- **Exclude child attributes**: Attributes that should not be combined in parent products.
+- **Skip children for composite type(s)**: Composite product types for which child attributes should be excluded.
+- **Price field**: Select which field is used as "price" in Tweakwise. The first nonzero value is exported.
+- **Batch size categories**: Set the batch size for categories during export. Lower for less memory, higher for more speed.
+- **Batch size products**: Set the batch size for products during export.
+- **Batch size products children**: Set the batch size for product children during export.
+- **Schedule full export**: Cron schedule for generating the feed. Leave empty to disable export by cron.
+- **State**: Shows the current export state.
+- **Schedule exports**: Start exports on next cron run.
+
+### Export Stock Settings
+
+- **Schedule stock export**: Cron schedule for stock feed export.
+- **State (stock)**: Shows the current stock export state.
+- **Schedule stock export (start)**: Start stock exports on next cron run.
+- **Tweakwise Import API Url for stock feed**: API trigger URL for stock feed import.
+
+### Export Price Settings
+
+- **Schedule price export**: Cron schedule for price feed export.
+- **State (price)**: Shows the current price export state.
+- **Schedule price export (start)**: Start price exports on next cron run.
+- **Tweakwise Import API Url for price feed**: API trigger URL for price feed import.
 
 ### Visibility settings
 Magento has multiple visibility settings, tweakwise only knows visible products meaning that if a product is in the feed then it will be visible while navigating and searching.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ If you switch from to normal export to groupcode export, you will need to do the
 5. Enable Stores->configuration->catalog->tweakwise->general->Grouped products
 6. Clear the cache
 
-During the switch the catalog may be empty. If the image url are not correct no product images may be shown in magento. Please contact support if you have issues with this.
+During the switch the catalog may be empty. If the image url are not correct no product images may be shown in magento.
+If you use recommendations, add an attribute with the name "groupcode" in tweakwise and use it as an api attribute. Without this recommendations will not work.
+Please contact Tweakwise support if you have any issues with the groupcode export.
 
 ## A note on the feed implementation
 Magento's native interfaces and handlers for data retrieval were deemed to slow for a large catalog.

--- a/README.md
+++ b/README.md
@@ -110,7 +110,6 @@ All export settings can be found under Stores -> Configuration -> Catalog -> Twe
 - **Exclude child attributes**: Attributes that should not be combined in parent products.
 - **Skip children for composite type(s)**: Composite product types for which child attributes should be excluded.
 - **Price field**: Select which field is used as "price" in Tweakwise. The first nonzero value is exported.
-- **Calculate combined prices**: Set this to yes if you want to send te combined price (of all children) of an grouped/bundle product to tweakwise. Instead of the min/max price of one of the children.
 - **Batch size categories**: Set the batch size for categories during export. Lower for less memory, higher for more speed.
 - **Batch size products**: Set the batch size for products during export.
 - **Batch size products children**: Set the batch size for product children during export.
@@ -135,7 +134,7 @@ All export settings can be found under Stores -> Configuration -> Catalog -> Twe
 ### Visibility settings
 Magento has multiple visibility settings, tweakwise only knows visible products meaning that if a product is in the feed then it will be visible while navigating and searching.
 The magento visibility setting is exported in the feed so you can add a hidden filter to your tweakwise template to artificially use the correct settings.
-If you do this then exclude the visibility attribute from child products (see "Export Settings").
+If you do this then exclude the visibility attribute from child products (see "Export Settings"). If you use groupcode export then you need to use the parent_visibility as an hidden filter instead of visibility.
 
 ## Contributors 
 If you want to create a pull request as a contributor, use the guidelines of semantic-release. semantic-release automates the whole package release workflow including: determining the next version number, generating the release notes, and publishing the package.

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -24,7 +24,7 @@
                     <label>Store Level Export</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
-                <field id="grouped_export_enabled" translate="label" type="select" sortOrder="3" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="grouped_export_enabled" translate="label" type="select" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Use groupcode for export</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <depends>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -15,7 +15,7 @@
             <resource>Tweakwise_Magento2TweakwiseExport::config</resource>
             <group id="export" translate="label" type="text" sortOrder="1000" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Export</label>
-                <comment>Tweakwise Export version v7.3.2</comment>
+                <comment>Tweakwise Export version v7.4.0</comment>
                 <field id="enabled" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Enabled</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
@@ -23,6 +23,13 @@
                 <field id="store_level_export_enabled" translate="label" type="select" sortOrder="2" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Store Level Export</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
+                <field id="grouped_export_enabled" translate="label" type="select" sortOrder="3" showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>Use groupcode for export</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <depends>
+                        <field id="enabled">1</field>
+                    </depends>
                 </field>
 
                 <field id="feed_key" translate="label,comment" type="text" sortOrder="20" showInDefault="1" showInWebsite="0" showInStore="0">

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -12,6 +12,7 @@
         <tweakwise>
             <export>
                 <enabled>0</enabled>
+                <grouped_export_enabled>0</grouped_export_enabled>
                 <schedule>0 3 * * *</schedule>
                 <archive/>
                 <validate>0</validate>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -76,10 +76,10 @@
         <arguments>
             <!-- update batchSize if memory is less important then speed -->
             <argument name="collectionDecorators" xsi:type="array">
+                <item name="category_reference" xsi:type="object">Tweakwise\Magento2TweakwiseExport\Model\Write\Products\CollectionDecorator\CategoryReference</item>
                 <item name="children" xsi:type="object">Tweakwise\Magento2TweakwiseExport\Model\Write\Products\CollectionDecorator\Children</item>
                 <item name="stock_data" xsi:type="object">Tweakwise\Magento2TweakwiseExport\Model\Write\Products\CollectionDecorator\StockData</item>
                 <item name="children_attributes" xsi:type="object">Tweakwise\Magento2TweakwiseExport\Model\Write\Products\CollectionDecorator\ChildrenAttributes</item>
-                <item name="category_reference" xsi:type="object">Tweakwise\Magento2TweakwiseExport\Model\Write\Products\CollectionDecorator\CategoryReference</item>
                 <item name="price" xsi:type="object">Tweakwise\Magento2TweakwiseExport\Model\Write\Products\CollectionDecorator\Price</item>
                 <item name="website_link" xsi:type="object">Tweakwise\Magento2TweakwiseExport\Model\Write\Products\CollectionDecorator\WebsiteLink</item>
                 <item name="review" xsi:type="object">Tweakwise\Magento2TweakwiseExport\Model\Write\Products\CollectionDecorator\Review</item>


### PR DESCRIPTION
# Grouped export
If you have groupcode enabled all products are exported with their groupcode. All variants of a product (configurable, grouped, bundle) are linked together using the groupcode. If this is enabled all variants are separated products in Tweakwise. Use this if you want to filter out products based on variant data.
If you switch from to normal export to groupcode export, you will need to do the following:
1. Enable groupcode export in the configuration.
2. Run the tweakwise:export command to generate the feed.
3. Make sure the image urls are correct in Tweakwise.
4. Import the feed into Tweakwise and publish the catalog.
5. Enable Stores->configuration->catalog->tweakwise->general->Grouped products
6. Clear the cache


During the switch the catalog may be empty. If the image url are not correct no product images may be shown in magento.
If you use recommendations, add an attribute with the name "groupcode" in tweakwise and use it as an api attribute. Without this recommendations will not work.
Please contact Tweakwise support if you have any issues with the groupcode export.