### PR TITLE
fix: wrong prices from group/bundle products

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -324,7 +324,7 @@ class Config
      * @param Store $store
      * @return bool
      */
-    public function calculateCombinedPrices(Store $store): bool
+    public function calculateCombinedPrices(?StoreInterface $store = null): bool
     {
         return (bool) $this->config->isSetFlag(self::CALCULATE_COMPOSITE_PRICES, ScopeInterface::SCOPE_STORE, $store);
     }

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -321,7 +321,7 @@ class Config
     }
 
     /**
-     * @param Store $store
+     * @param StoreInterface|null $store
      * @return bool
      */
     public function calculateCombinedPrices(?StoreInterface $store = null): bool

--- a/Model/Write/Products/CollectionDecorator/Price.php
+++ b/Model/Write/Products/CollectionDecorator/Price.php
@@ -98,17 +98,22 @@ class Price implements DecoratorInterface
      */
     private function applyCombinedPrices(array $row, DataObject $product, Store $store): array
     {
-        if ($this->config->calculateCombinedPrices($store)) {
-            if ($this->isGroupedProduct($product)) {
-                $prices = $this->calculateGroupedProductPrice((int)$product->getId());
-                foreach ($prices as $price => $value) {
-                    $row[$price] = $value;
-                }
-            } elseif ($this->isBundleProduct($product)) {
-                $prices = $this->calculateBundleProductPrice((int)$product->getId());
-                foreach ($prices as $price => $value) {
-                    $row[$price] = $value;
-                }
+        if (!$this->config->calculateCombinedPrices($store)) {
+            return $row;
+        }
+
+        if ($this->isGroupedProduct($product)) {
+            $prices = $this->calculateGroupedProductPrice((int)$product->getId());
+            foreach ($prices as $price => $value) {
+                $row[$price] = $value;
+            }
+            return $row;
+        }
+
+        if ($this->isBundleProduct($product)) {
+            $prices = $this->calculateBundleProductPrice((int)$product->getId());
+            foreach ($prices as $price => $value) {
+                $row[$price] = $value;
             }
         }
 
@@ -297,7 +302,7 @@ class Price implements DecoratorInterface
             $optionId = $selection->getOptionId();
             $grouped[$optionId][] = $selection;
         }
-        
+
         return $grouped;
     }
 

--- a/Model/Write/Products/CollectionDecorator/Price.php
+++ b/Model/Write/Products/CollectionDecorator/Price.php
@@ -111,6 +111,7 @@ class Price implements DecoratorInterface
                 }
             }
         }
+
         return $row;
     }
 
@@ -124,6 +125,7 @@ class Price implements DecoratorInterface
         foreach ($priceFields as $priceField) {
             $row[$priceField] = $this->calculatePrice((float)$row[$priceField]);
         }
+
         return $row;
     }
 
@@ -295,6 +297,7 @@ class Price implements DecoratorInterface
             $optionId = $selection->getOptionId();
             $grouped[$optionId][] = $selection;
         }
+        
         return $grouped;
     }
 

--- a/Model/Write/Products/CollectionDecorator/Price.php
+++ b/Model/Write/Products/CollectionDecorator/Price.php
@@ -107,6 +107,7 @@ class Price implements DecoratorInterface
             foreach ($prices as $price => $value) {
                 $row[$price] = $value;
             }
+
             return $row;
         }
 

--- a/Model/Write/Products/CollectionDecorator/Price.php
+++ b/Model/Write/Products/CollectionDecorator/Price.php
@@ -94,6 +94,7 @@ class Price implements DecoratorInterface
     /**
      * @param array $row
      * @param DataObject $product
+     * @param Store $store
      * @return array
      */
     private function applyCombinedPrices(array $row, DataObject $product, Store $store): array


### PR DESCRIPTION
This fixes an bug with the wrong prices for grouped/bundle products

How to reproduce

- Have an group/bundle product with an valid special price for one or more of the products in the group/bundle.
- Enable the setting 'calculate group/bundle prices' in the tweakwise export settings
- Run the tweakwise export and see that the price of the group/bundle product is not correct. (not incl special price)