### PR TITLE
Fix: category url with store

### DIFF
--- a/Model/Write/Categories.php
+++ b/Model/Write/Categories.php
@@ -233,7 +233,7 @@ class Categories implements WriterInterface
             ]
         );
         if ($rewrite) {
-            return $this->url->getDirectUrl($rewrite->getRequestPath());
+            return rtrim($store->getBaseUrl(), '/') . '/' . ltrim($rewrite->getRequestPath(), '/');
         }
 
         return null;


### PR DESCRIPTION
When having multiple stores and the store code in the url. The category urls of the second store (and up) are wrong. They have the store code of the first store in the url.