### PR TITLE
Feat: select how created/update date are exported

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -42,6 +42,7 @@ class Config
     public const PATH_SKIP_CHILD_BY_COMPOSITE_TYPE = 'tweakwise/export/skip_child_by_composite_type';
     public const CALCULATE_COMPOSITE_PRICES = 'tweakwise/export/calculate_composite_prices';
     public const PATH_GROUPED_EXPORT_ENABLED = 'tweakwise/export/grouped_export_enabled';
+    public const PATH_DATE_FIELD = 'tweakwise/export/date_field';
 
     /**
      * Default feed filename
@@ -327,5 +328,21 @@ class Config
     public function calculateCombinedPrices(Store $store): bool
     {
         return (bool) $this->config->isSetFlag(self::CALCULATE_COMPOSITE_PRICES, ScopeInterface::SCOPE_STORE, $store);
+    }
+
+    /**
+     * @return string
+     */
+    public function getDateField(): string
+    {
+        return (string) $this->config->getValue(self::PATH_DATE_FIELD);
+    }
+
+    /**
+     * @return array
+     */
+    public function getDateAttributes(): array
+    {
+        return ['created_at', 'updated_at'];
     }
 }

--- a/Model/Config/Source/DateField.php
+++ b/Model/Config/Source/DateField.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tweakwise\Magento2TweakwiseExport\Model\Config\Source;
+
+use Magento\Framework\Option\ArrayInterface;
+
+class DateField implements ArrayInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function toOptionArray()
+    {
+        $dateFields = [
+            'all' => 'All Dates',
+            'min' => 'Min Date',
+            'max' => 'Max Date',
+        ];
+
+        return $dateFields;
+    }
+}

--- a/Model/Config/Source/DateField.php
+++ b/Model/Config/Source/DateField.php
@@ -2,9 +2,9 @@
 
 namespace Tweakwise\Magento2TweakwiseExport\Model\Config\Source;
 
-use Magento\Framework\Option\ArrayInterface;
+use Magento\Framework\Data\OptionSourceInterface;
 
-class DateField implements ArrayInterface
+class DateField implements OptionSourceInterface
 {
     /**
      * Return array of options as value-label pairs
@@ -14,9 +14,9 @@ class DateField implements ArrayInterface
     public function toOptionArray(): array
     {
         return [
-            'all' => 'All Dates',
-            'min' => 'Min Date',
-            'max' => 'Max Date',
+            ['value' => 'all', 'label' => __('All Dates')],
+            ['value' => 'min', 'label' => __('Min Date')],
+            ['value' => 'max', 'label' => __('Max Date')],
         ];
     }
 }

--- a/Model/Config/Source/DateField.php
+++ b/Model/Config/Source/DateField.php
@@ -7,16 +7,16 @@ use Magento\Framework\Option\ArrayInterface;
 class DateField implements ArrayInterface
 {
     /**
-     * {@inheritdoc}
+     * Return array of options as value-label pairs
+     *
+     * @return array
      */
-    public function toOptionArray()
+    public function toOptionArray(): array
     {
-        $dateFields = [
+        return [
             'all' => 'All Dates',
             'min' => 'Min Date',
             'max' => 'Max Date',
         ];
-
-        return $dateFields;
     }
 }

--- a/Model/Write/Products/CollectionDecorator/ChildrenAttributes.php
+++ b/Model/Write/Products/CollectionDecorator/ChildrenAttributes.php
@@ -6,7 +6,6 @@ use Tweakwise\Magento2TweakwiseExport\Model\Config;
 use Tweakwise\Magento2TweakwiseExport\Model\Write\Products\Collection;
 use Tweakwise\Magento2TweakwiseExport\Model\Write\Products\CompositeExportEntityInterface;
 use Tweakwise\Magento2TweakwiseExport\Model\Write\Stock\Collection as StockCollection;
-use function in_array;
 
 class ChildrenAttributes implements DecoratorInterface
 {

--- a/Model/Write/Products/CollectionDecorator/ChildrenAttributes.php
+++ b/Model/Write/Products/CollectionDecorator/ChildrenAttributes.php
@@ -6,6 +6,7 @@ use Tweakwise\Magento2TweakwiseExport\Model\Config;
 use Tweakwise\Magento2TweakwiseExport\Model\Write\Products\Collection;
 use Tweakwise\Magento2TweakwiseExport\Model\Write\Products\CompositeExportEntityInterface;
 use Tweakwise\Magento2TweakwiseExport\Model\Write\Stock\Collection as StockCollection;
+use function in_array;
 
 class ChildrenAttributes implements DecoratorInterface
 {
@@ -49,6 +50,11 @@ class ChildrenAttributes implements DecoratorInterface
             foreach ($exportEntity->getExportChildren() as $child) {
                 foreach ($child->getAttributes() as $attributeData) {
                     if ($this->config->getSkipChildAttribute($attributeData['attribute'])) {
+                        continue;
+                    }
+
+                    if (in_array($attributeData['attribute'], $this->config->getDateAttributes(), true)) {
+                        $exportEntity->addDate($attributeData['attribute'], $attributeData['value']);
                         continue;
                     }
 

--- a/Model/Write/Products/DateFieldType.php
+++ b/Model/Write/Products/DateFieldType.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tweakwise\Magento2TweakwiseExport\Model\Write\Products;
+
+enum DateFieldType: string
+{
+    case MIN = 'min';
+    case MAX = 'max';
+    case ALL = 'all';
+}

--- a/Model/Write/Products/ExportEntity.php
+++ b/Model/Write/Products/ExportEntity.php
@@ -130,19 +130,19 @@ class ExportEntity
             'entity_id' => function ($value) {
                 $this->id = (int) $value;
             },
-            'type_id'   => function ($value) {
+            'type_id' => function ($value) {
                 $this->setTypeId((string) $value);
             },
-            'status'    => function ($value) {
+            'status' => function ($value) {
                 $this->setStatus((int) $value);
             },
-            'visibility'=> function ($value) {
+            'visibility' => function ($value) {
                 $this->setVisibility((int) $value);
             },
-            'name'      => function ($value) {
+            'name' => function ($value) {
                 $this->setName((string) $value);
             },
-            'price'     => function ($value) {
+            'price' => function ($value) {
                 $this->setPrice((float) $value);
             },
         ];

--- a/Model/Write/Products/ExportEntity.php
+++ b/Model/Write/Products/ExportEntity.php
@@ -127,12 +127,24 @@ class ExportEntity
     public function setFromArray(array $data): void
     {
         $handlers = [
-            'entity_id' => function ($value) { $this->id = (int) $value; },
-            'type_id'   => function ($value) { $this->setTypeId((string) $value); },
-            'status'    => function ($value) { $this->setStatus((int) $value); },
-            'visibility'=> function ($value) { $this->setVisibility((int) $value); },
-            'name'      => function ($value) { $this->setName((string) $value); },
-            'price'     => function ($value) { $this->setPrice((float) $value); },
+            'entity_id' => function ($value) {
+                $this->id = (int) $value;
+            },
+            'type_id'   => function ($value) {
+                $this->setTypeId((string) $value);
+            },
+            'status'    => function ($value) {
+                $this->setStatus((int) $value);
+            },
+            'visibility'=> function ($value) {
+                $this->setVisibility((int) $value);
+            },
+            'name'      => function ($value) {
+                $this->setName((string) $value);
+            },
+            'price'     => function ($value) {
+                $this->setPrice((float) $value);
+            },
         ];
 
         $dateFields = $this->config->getDateAttributes();

--- a/Model/Write/Products/ExportEntity.php
+++ b/Model/Write/Products/ExportEntity.php
@@ -12,6 +12,7 @@ use Magento\Store\Model\StoreManagerInterface;
 use Magento\Store\Model\Store;
 use Tweakwise\Magento2TweakwiseExport\Model\Config;
 use Magento\Catalog\Model\Product\Type;
+
 use function in_array;
 
 /**
@@ -284,12 +285,18 @@ class ExportEntity
     public function addDate(string $attribute, string $value): void
     {
         if ($this->config->getDateField() === 'min') {
-            if (!isset($this->attributes[$attribute]) || strtotime($value) < strtotime(current($this->attributes[$attribute]))) {
+            if (
+                !isset($this->attributes[$attribute]) ||
+                strtotime($value) < strtotime(current($this->attributes[$attribute]))
+            ) {
                 $this->attributes[$attribute] = [$value];
                 return;
             }
         } elseif ($this->config->getDateField() === 'max') {
-            if (!isset($this->attributes[$attribute]) || strtotime($value) > strtotime(current($this->attributes[$attribute]))) {
+            if (
+                !isset($this->attributes[$attribute]) ||
+                strtotime($value) > strtotime(current($this->attributes[$attribute]))
+            ) {
                 $this->attributes[$attribute] = [$value];
             }
         }

--- a/Model/Write/Products/ExportEntity.php
+++ b/Model/Write/Products/ExportEntity.php
@@ -12,6 +12,7 @@ use Magento\Store\Model\StoreManagerInterface;
 use Magento\Store\Model\Store;
 use Tweakwise\Magento2TweakwiseExport\Model\Config;
 use Magento\Catalog\Model\Product\Type;
+use function in_array;
 
 /**
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
@@ -280,12 +281,31 @@ class ExportEntity
         return $this->categories;
     }
 
+    public function addDate(string $attribute, string $value): void
+    {
+        if ($this->config->getDateField() === 'min') {
+            if (!isset($this->attributes[$attribute]) || strtotime($value) < strtotime(current($this->attributes[$attribute]))) {
+                $this->attributes[$attribute] = [$value];
+                return;
+            }
+        } elseif ($this->config->getDateField() === 'max') {
+            if (!isset($this->attributes[$attribute]) || strtotime($value) > strtotime(current($this->attributes[$attribute]))) {
+                $this->attributes[$attribute] = [$value];
+            }
+        }
+    }
+
     /**
      * @param string $attribute
      * @param mixed $value
      */
     public function addAttribute(string $attribute, $value): void
     {
+        if ($this->config->getDateField() !== 'all' && in_array($attribute, $this->config->getDateAttributes(), true)) {
+            $this->addDate($attribute, (string) $value);
+            return;
+        }
+
         if (!isset($this->attributes[$attribute])) {
             $this->attributes[$attribute] = [];
         }

--- a/Model/Write/Products/ExportEntity.php
+++ b/Model/Write/Products/ExportEntity.php
@@ -94,8 +94,6 @@ class ExportEntity
      */
     protected $typeId;
 
-    protected DateFieldType $dateFieldType;
-
     /**
      * ExportEntity constructor.
      *
@@ -140,17 +138,16 @@ class ExportEntity
         $dateFields = $this->config->getDateAttributes();
 
         foreach ($data as $key => $value) {
-            if (isset($handlers[$key])) {
-                $handlers[$key]($value);
-                $this->addAttribute($key, $value);
-                continue;
-            } elseif (in_array($key, $dateFields, true)) {
+            if (in_array($key, $dateFields, true)) {
                 $this->addDate($key, $value);
                 continue;
             }
 
-            $this->addAttribute($key, $value);
+            if (isset($handlers[$key])) {
+                $handlers[$key]($value);
+            }
 
+            $this->addAttribute($key, $value);
         }
     }
 

--- a/Model/Write/Products/ExportEntity.php
+++ b/Model/Write/Products/ExportEntity.php
@@ -12,7 +12,6 @@ use Magento\Store\Model\StoreManagerInterface;
 use Magento\Store\Model\Store;
 use Tweakwise\Magento2TweakwiseExport\Model\Config;
 use Magento\Catalog\Model\Product\Type;
-use Tweakwise\Magento2TweakwiseExport\Model\Write\Products\DateFieldType;
 
 /**
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ All export settings can be found under Stores -> Configuration -> Catalog -> Twe
 - **Export out of stock combined product children**: Export out-of-stock child attributes in parent products.
 - **Exclude child attributes**: Attributes that should not be combined in parent products.
 - **Skip children for composite type(s)**: Composite product types for which child attributes should be excluded.
+- **Date field**: Select how the created and updated date is exported.
 - **Price field**: Select which field is used as "price" in Tweakwise. The first nonzero value is exported.
 - **Batch size categories**: Set the batch size for categories during export. Lower for less memory, higher for more speed.
 - **Batch size products**: Set the batch size for products during export.

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -109,6 +109,15 @@
                     </depends>
                 </field>
 
+                <field id="date_field" translate="label,comment" type="select" sortOrder="100" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Date fields (created at/ updated at)</label>
+                    <comment>Choose which dates to include: All exports every date (including child records), Min exports only the earliest, and Max exports only the latest.</comment>
+                    <source_model>Tweakwise\Magento2TweakwiseExport\Model\Config\Source\DateField</source_model>
+                    <depends>
+                        <field id="enabled">1</field>
+                    </depends>
+                </field>
+
                 <field id="price_field" translate="label,comment" type="select" sortOrder="100" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Price field</label>
                     <comment>Select which field is used as "price" in Tweakwise, selection will select each price field in order and return the first nonzero value. Prices are exported from price index table, note that catalogrule prices are available in field "min_price" so it could be that this value is lowed then for example "final_price". If your configurable / bundle products do not have a price attribute filled this will be zero.</comment>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -110,7 +110,7 @@
                 </field>
 
                 <field id="date_field" translate="label,comment" type="select" sortOrder="100" showInDefault="1" showInWebsite="1" showInStore="1">
-                    <label>Date fields (created at/ updated at)</label>
+                    <label>Date fields (created at / updated at)</label>
                     <comment>Choose which dates to include: All exports every date (including child records), Min exports only the earliest, and Max exports only the latest.</comment>
                     <source_model>Tweakwise\Magento2TweakwiseExport\Model\Config\Source\DateField</source_model>
                     <depends>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -24,6 +24,7 @@
                 <exclude_child_attributes>url_key,small_image,small_image_label,thumbnail_label,status,tax_class_id,type_id,required_options,visibility</exclude_child_attributes>
                 <skip_child_by_composite_type/>
                 <price_field>min_price,final_price,price,max_price</price_field>
+                <date_field>all</date_field>
                 <batch_size_categories>5000</batch_size_categories>
                 <batch_size_products>5000</batch_size_products>
                 <batch_size_products_children>5000</batch_size_products_children>


### PR DESCRIPTION
Added an setting that determines how the created/updated date is exported.

- All (default) Export all the available dates of an product.
- Min. Export the earliest date of an product 
- Max. Export the latest date of an product

The dates exported are of an product incl its children.