### PR TITLE
Ignore phpcs issue for override method

### DIFF
--- a/Model/Write/Categories/Iterator.php
+++ b/Model/Write/Categories/Iterator.php
@@ -127,6 +127,7 @@ class Iterator extends EavIterator
      * @param array $result
      *
      * @return bool
+     * phpcs:disable Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClass
      */
     public function shouldProcess(array $result): bool
     {


### PR DESCRIPTION
This is a method for creating a plugin or overriding this function. Therefore, the $result variable is currently not used.