### PR TITLE
Add store filter to EAV iterator

### DIFF
--- a/Console/Command/ExportCommand.php
+++ b/Console/Command/ExportCommand.php
@@ -178,7 +178,7 @@ class ExportCommand extends Command
                         $feedFile = $this->config->getDefaultFeedFile($store, $type);
                     }
 
-                    $output->writeln("<info>generatig feed for {$store->getCode()}</info>");
+                    $output->writeln("<info>generating feed for {$store->getCode()}</info>");
                     $this->export->generateToFile($feedFile, $validate, $store, $type);
                     $output->writeln("<info>feed file: {$feedFile}</info>");
                 } else {

--- a/Model/Write/Categories/Iterator.php
+++ b/Model/Write/Categories/Iterator.php
@@ -106,4 +106,10 @@ class Iterator extends EavIterator
 
         return $select;
     }
+
+    protected function addStoreFilter(\Zend_Db_Select $select): void
+    {
+        $storeId = $this->store->getRootCategoryId();
+        $select->where('path like ?', '%/'.$storeId.'%');
+    }
 }

--- a/Model/Write/EavIterator.php
+++ b/Model/Write/EavIterator.php
@@ -326,6 +326,7 @@ class EavIterator implements IteratorAggregate
         if (!isset($this->entitySet[$storeId])) {
             $select = $this->getConnection()->select();
             $select->from($this->getEntityType()->getEntityTable());
+            $this->addStoreFilter($select);
             $select->reset('columns')->columns(['entity_id', 'created_at', 'updated_at', 'attribute_set_id']);
             $this->addEntityBatchOrder($select);
 
@@ -575,5 +576,10 @@ class EavIterator implements IteratorAggregate
             ->where('cpe.type_id = ?', Configurable::TYPE_CODE);
 
         $this->parentRelations = $connection->fetchPairs($select);
+    }
+
+    protected function addStoreFilter(\Zend_Db_Select $select): void
+    {
+        // Override in subclass to add store filter functionality
     }
 }

--- a/Model/Write/Products/CollectionDecorator/Price.php
+++ b/Model/Write/Products/CollectionDecorator/Price.php
@@ -104,7 +104,7 @@ class Price implements DecoratorInterface
         }
 
         if ($this->isGroupedProduct($product)) {
-            $prices = $this->calculateGroupedProductPrice((int)$product->getId());
+            $prices = $this->calculateGroupedProductPrice($product);
             foreach ($prices as $price => $value) {
                 $row[$price] = $value;
             }
@@ -113,7 +113,7 @@ class Price implements DecoratorInterface
         }
 
         if ($this->isBundleProduct($product)) {
-            $prices = $this->calculateBundleProductPrice((int)$product->getId());
+            $prices = $this->calculateBundleProductPrice($product);
             foreach ($prices as $price => $value) {
                 $row[$price] = $value;
             }
@@ -208,15 +208,14 @@ class Price implements DecoratorInterface
     }
 
     /**
-     * @param int $entityId
+     * @param DataObject $entityId
      * @param callable $getAssociatedItems
      * @return array
      */
     protected function calculateProductPrice(
-        int $entityId,
+        DataObject $product,
         callable $getAssociatedItems
     ): array {
-        $product = $this->collectionFactory->create()->getItemById($entityId);
         $associatedItems = $getAssociatedItems($product);
 
         // Convert collection to array if necessary
@@ -243,13 +242,13 @@ class Price implements DecoratorInterface
     }
 
     /**
-     * @param int $entityId
+     * @param DataObject $product
      * @return array
      */
-    protected function calculateGroupedProductPrice(int $entityId): array
+    protected function calculateGroupedProductPrice(DataObject $product): array
     {
         return $this->calculateProductPrice(
-            $entityId,
+            $product,
             function ($product) {
                 return $product->getTypeInstance()->getAssociatedProducts($product);
             }
@@ -257,10 +256,10 @@ class Price implements DecoratorInterface
     }
 
     /**
-     * @param int $entityId
+     * @param DataObject|null $product
      * @return array
      */
-    protected function calculateBundleProductPrice(int $entityId): array
+    protected function calculateBundleProductPrice(?DataObject $product): array
     {
         $price = [
             'min_price' => 0.0,
@@ -268,7 +267,6 @@ class Price implements DecoratorInterface
             'final_price' => 0.0,
         ];
 
-        $product = $this->collectionFactory->create()->getItemById($entityId);
         if ($product === null) {
             return $price;
         }

--- a/Model/Write/Products/Iterator.php
+++ b/Model/Write/Products/Iterator.php
@@ -144,4 +144,17 @@ class Iterator extends EavIterator
             ];
         }
     }
+
+    protected function addStoreFilter(\Zend_Db_Select $select): void
+    {
+        $storeTable = $this->getResources()->getTableName('store');
+        $cpwTable = $this->getResources()->getTableName('catalog_product_website');
+
+        $subSelect = $this->getConnection()->select()
+            ->from($storeTable, ['website_id'])
+            ->where('store_id = ?', $this->store->getId());
+
+        $select->join(['cpw' => $cpwTable], 'cpw.product_id = ' . $this->getEntityType()->getEntityTable() . '.entity_id')
+            ->where('cpw.website_id = (' . $subSelect . ')');
+    }
 }


### PR DESCRIPTION
While debugging the exporter speed for a small website in the same Magento installation as a very large website I found that the EAV iterator loops over ALL products and later decides if they should be exported. This is especially costly when there are a large amount of attributes for each product to load. This change add the store filter earlier in the exporting process to prevent unnecessary iteration.

Also a small change was made to the PriceDecorator to pass the Product as a parameter instead of the productId to prevent creating a collection of ALL products in the database to retrieve a single one that was already loaded anyway.

Let me know if any changes are needed or extra information is required.