### PR TITLE
Add store filter to eav iterator

### DIFF
--- a/Console/Command/ExportCommand.php
+++ b/Console/Command/ExportCommand.php
@@ -180,7 +180,7 @@ class ExportCommand extends Command
                         $feedFile = $this->config->getDefaultFeedFile($store, $type);
                     }
 
-                    $output->writeln(sprintf('<info>generatig feed for %s</info>', $store->getCode()));
+                    $output->writeln(sprintf('<info>generating feed for %s</info>', $store->getCode()));
                     $this->export->generateToFile($feedFile, $validate, $store, $type);
                     $output->writeln(sprintf('<info>feed file:  %s</info>', $feedFile));
                 } else {

--- a/Model/Write/Categories/Iterator.php
+++ b/Model/Write/Categories/Iterator.php
@@ -134,7 +134,6 @@ class Iterator extends EavIterator
         return true;
     }
 
-
     /**
      * {@inheritdoc}
      */

--- a/Model/Write/Categories/Iterator.php
+++ b/Model/Write/Categories/Iterator.php
@@ -133,4 +133,14 @@ class Iterator extends EavIterator
     {
         return true;
     }
+
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function addStoreFilter(\Zend_Db_Select $select): void
+    {
+        $storeId = $this->store->getRootCategoryId();
+        $select->where('path like ?', '%/'.$storeId.'%');
+    }
 }

--- a/Model/Write/EavIterator.php
+++ b/Model/Write/EavIterator.php
@@ -328,6 +328,7 @@ class EavIterator implements IteratorAggregate
         if (!isset($this->entitySet[$storeId])) {
             $select = $this->getConnection()->select();
             $select->from($this->getEntityType()->getEntityTable());
+            $this->addStoreFilter($select);
             $select->reset('columns')->columns(['entity_id', 'created_at', 'updated_at', 'attribute_set_id']);
             $this->addEntityBatchOrder($select);
 
@@ -581,5 +582,14 @@ class EavIterator implements IteratorAggregate
             ->where('cpe.type_id = ?', Configurable::TYPE_CODE);
 
         $this->parentRelations = $connection->fetchPairs($select);
+    }
+
+    /**
+     * @param Zend_Db_Select $select
+     * @return void
+     */
+    protected function addStoreFilter(\Zend_Db_Select $select): void
+    {
+        // Override in subclass to add store filter functionality
     }
 }

--- a/Model/Write/Products/CollectionDecorator/Price.php
+++ b/Model/Write/Products/CollectionDecorator/Price.php
@@ -106,7 +106,7 @@ class Price implements DecoratorInterface
         }
 
         if ($this->isGroupedProduct($product)) {
-            $prices = $this->calculateGroupedProductPrice((int)$product->getId());
+            $prices = $this->calculateGroupedProductPrice($product);
             foreach ($prices as $price => $value) {
                 $row[$price] = $value;
             }
@@ -115,7 +115,7 @@ class Price implements DecoratorInterface
         }
 
         if ($this->isBundleProduct($product)) {
-            $prices = $this->calculateBundleProductPrice((int)$product->getId());
+            $prices = $this->calculateBundleProductPrice($product);
             foreach ($prices as $price => $value) {
                 $row[$price] = $value;
             }
@@ -210,15 +210,15 @@ class Price implements DecoratorInterface
     }
 
     /**
-     * @param int $entityId
+     * @param DataObject $product
      * @param callable $getAssociatedItems
      * @return array
      */
     protected function calculateProductPrice(
-        int $entityId,
+        DataObject $product,
         callable $getAssociatedItems
     ): array {
-        $product = $this->collectionFactory->create()->getItemById($entityId);
+        $product = $this->collectionFactory->create()->getItemById($product);
         $associatedItems = $getAssociatedItems($product);
 
         // Convert collection to array if necessary
@@ -245,13 +245,13 @@ class Price implements DecoratorInterface
     }
 
     /**
-     * @param int $entityId
+     * @param DataObject $product
      * @return array
      */
-    protected function calculateGroupedProductPrice(int $entityId): array
+    protected function calculateGroupedProductPrice(DataObject $product): array
     {
         return $this->calculateProductPrice(
-            $entityId,
+            $product,
             function ($product) {
                 return $product->getTypeInstance()->getAssociatedProducts($product);
             }
@@ -259,21 +259,16 @@ class Price implements DecoratorInterface
     }
 
     /**
-     * @param int $entityId
+     * @param DataObject $product
      * @return array
      */
-    protected function calculateBundleProductPrice(int $entityId): array
+    protected function calculateBundleProductPrice(DataObject $product): array
     {
         $price = [
             'min_price' => 0.0,
             'max_price' => 0.0,
             'final_price' => 0.0,
         ];
-
-        $product = $this->collectionFactory->create()->getItemById($entityId);
-        if ($product === null) {
-            return $price;
-        }
 
         // @phpstan-ignore-next-line
         $selections = $product->getTypeInstance()->getSelectionsCollection(

--- a/Model/Write/Products/Iterator.php
+++ b/Model/Write/Products/Iterator.php
@@ -146,4 +146,20 @@ class Iterator extends EavIterator
             ];
         }
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function addStoreFilter(\Zend_Db_Select $select): void
+    {
+        $storeTable = $this->getResources()->getTableName('store');
+        $cpwTable = $this->getResources()->getTableName('catalog_product_website');
+
+        $subSelect = $this->getConnection()->select()
+            ->from($storeTable, ['website_id'])
+            ->where('store_id = ?', $this->store->getId());
+
+        $select->join(['cpw' => $cpwTable], 'cpw.product_id = ' . $this->getEntityType()->getEntityTable() . '.entity_id')
+            ->where('cpw.website_id = (' . $subSelect . ')');
+    }
 }


### PR DESCRIPTION
- Pass already loaded product as parameter instead of creating collection of all products in database
- Add store filter to sql to prevent unneeded iteration
- Added doc-blocks

Using our customer's dataset yields the following results:
- **Before:** Feed written in 146.61s using 1416.33Mb memory
- **After:** Feed written in 2.68s using 148Mb memory