### PR TITLE
Fix: visibility

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -203,6 +203,9 @@ class Config
             $this->skipAttributes = array_flip($skipAttributes);
         }
 
+        //add visibility to skip attributes to prevent issues with parent products when parent visibility is not set to "Catalog, Search"
+        $this->skipAttributes['visibility'] = true;
+
         if ($attribute === null) {
             return array_keys($this->skipAttributes);
         }

--- a/Model/Write/Products/ExportEntity.php
+++ b/Model/Write/Products/ExportEntity.php
@@ -210,6 +210,9 @@ class ExportEntity
      */
     public function setVisibility(int $visibility): void
     {
+        if ($this->config->isGroupedExport()) {
+            $this->addAttribute('parent_visibility', $visibility);
+        }
         $this->visibility = $visibility;
     }
 


### PR DESCRIPTION
This pull request fixes two issues with the visibility

## Problem 1 
Previously, when a child product's visibility was added to a composite product's visibility attribute, it caused unintended behavior if the composite product itself was set to be hidden in either Search or the Catalog.

### Example Scenario:

Configurable Parent: Set to "Catalog" visibility, but "Not in Search."
Simple Child: Set to "Search" visibility, but "Not in Catalog."

### Current Situation (Before Fix)
When the child's visibility was injected or added to the composite product, the system incorrectly tried to display the composite product in areas where it should have remained hidden (like the Catalog or Search results), or it created conflicts in how Tweakwise filtered the grouped entity. This led to "ghost" products or items appearing in the wrong context because the composite product inherited visibility it should not have had.

### Fixed Situation
The logic has been refined to ensure that adding child visibility to a composite product does not break the composite's own visibility restrictions.

The composite product now correctly respects its own "Not Visible Individually" or "Catalog Only" status.

The system now accurately distinguishes between when to show the parent and when to allow the child to drive visibility without "leaking" that visibility back to the parent in an incorrect context.

### How to test

- Set up the products like in the example scenario
- Run the magento indexer
- Make sure grouped products is disabled in the export
- Run the tweakwise export
- See in the export feed that the visibility for the product only contains catalog. 

## The Problem 2 (grouped products)
When using grouped products, child visibility is currently ignored. This causes products to disappear from search results because the system only evaluates the Parent's visibility settings.

### Example Scenario:

Configurable Parent: Set to "Catalog" visibility, but "Not in Search."
Simple Child: Set to "Search" visibility, but "Not in Catalog."

### Current Situation
In the Catalog: The configurable product is shown, and the simple product is hidden. (Correct)
In Search: The simple product is NOT SHOWN because it is missing from the Tweakwise results. (Incorrect)

This happens because the system switches to "parent visibility" logic, but that logic does not include the child's visibility data. Since the Parent is hidden from Search, Tweakwise excludes the product entirely.

### Desired Situation
In the Catalog: The configurable product should be shown, but the simple product should be hidden.
In Search: The simple product should be shown, but the configurable product should be hidden.

How to test

Test test icm with https://github.com/EmicoEcommerce/Magento2Tweakwise/pull/353

Use the how to test in that issue