### PR TITLE
Fix: missing child info in batches

### DIFF
--- a/Model/Write/Products/CollectionDecorator/Children.php
+++ b/Model/Write/Products/CollectionDecorator/Children.php
@@ -2,7 +2,6 @@
 
 namespace Tweakwise\Magento2TweakwiseExport\Model\Write\Products\CollectionDecorator;
 
-use Tweakwise\Magento2TweakwiseExport\Exception\InvalidArgumentException;
 use Tweakwise\Magento2TweakwiseExport\Model\DbResourceHelper;
 use Tweakwise\Magento2TweakwiseExport\Model\Helper;
 use Tweakwise\Magento2TweakwiseExport\Model\Write\EavIteratorFactory;

--- a/Model/Write/Products/CollectionDecorator/Children.php
+++ b/Model/Write/Products/CollectionDecorator/Children.php
@@ -367,7 +367,11 @@ class Children implements DecoratorInterface
             return;
         }
 
-        if (!$parent instanceof ExportEntityConfigurable || !$child->shouldExport()) {
+        if (!$parent instanceof ExportEntityConfigurable) {
+            return;
+        }
+
+        if (!$this->config->isGroupedExport($collection->getStore()) && !$child->shouldExport()) {
             return;
         }
 

--- a/Model/Write/Products/CollectionDecorator/Children.php
+++ b/Model/Write/Products/CollectionDecorator/Children.php
@@ -300,8 +300,8 @@ class Children implements DecoratorInterface
      * @param int $parentId
      * @param int $childId
      * @param ChildOptions|null $childOptions
-     * phpcs:disable Magento2.CodeAnalysis.EmptyBlock.DetectedCatch
-     * phpcs:disable Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+     *
+     * @return void
      */
     protected function addChild(
         Collection|StockCollection|PriceCollection $collection,
@@ -321,6 +321,8 @@ class Children implements DecoratorInterface
      * @param Collection|StockCollection|PriceCollection $collection
      * @param int $childId
      * @param ChildOptions|null $childOptions
+     *
+     * @return ExportEntityChild
      */
     private function getOrCreateChildEntity(
         Collection|StockCollection|PriceCollection $collection,
@@ -349,6 +351,11 @@ class Children implements DecoratorInterface
 
     /**
      * @param Collection|StockCollection|PriceCollection $collection
+     * @param ExportEntity $parent
+     * @param ExportEntityChild $child
+     * @param int $childId
+     *
+     * @return void
      */
     private function addConfigurableChildToCollection(
         Collection|StockCollection|PriceCollection $collection,
@@ -367,6 +374,12 @@ class Children implements DecoratorInterface
         $collection->add($child);
     }
 
+    /**
+     * @param ExportEntity      $parent
+     * @param ExportEntityChild $child
+     *
+     * @return void
+     */
     private function addChildToParent(ExportEntity $parent, ExportEntityChild $child): void
     {
         if (!$parent instanceof CompositeExportEntityInterface) {
@@ -378,6 +391,11 @@ class Children implements DecoratorInterface
 
     /**
      * @param Collection|StockCollection|PriceCollection $collection
+     * @param ExportEntity $parent
+     * @param int $parentId
+     * @param int $childId
+     *
+     * @return void
      */
     private function enrichGroupedExportChild(
         Collection|StockCollection|PriceCollection $collection,

--- a/Model/Write/Products/CollectionDecorator/Children.php
+++ b/Model/Write/Products/CollectionDecorator/Children.php
@@ -9,6 +9,7 @@ use Tweakwise\Magento2TweakwiseExport\Model\Write\EavIteratorFactory;
 use Tweakwise\Magento2TweakwiseExport\Model\Write\Products\Collection;
 use Tweakwise\Magento2TweakwiseExport\Model\Write\Products\CollectionFactory;
 use Tweakwise\Magento2TweakwiseExport\Model\Write\Products\CompositeExportEntityInterface;
+use Tweakwise\Magento2TweakwiseExport\Model\Write\Products\ExportEntity;
 use Tweakwise\Magento2TweakwiseExport\Model\Write\Products\ExportEntityChild;
 use Tweakwise\Magento2TweakwiseExport\Model\Write\Products\ExportEntityConfigurable;
 use Tweakwise\Magento2TweakwiseExport\Model\Write\Products\ExportEntityFactory;
@@ -309,7 +310,24 @@ class Children implements DecoratorInterface
         int $childId,
         ?ChildOptions $childOptions = null
     ): void {
+        $child = $this->getOrCreateChildEntity($collection, $childId, $childOptions);
+        $parent = $collection->get($parentId);
 
+        $this->addConfigurableChildToCollection($collection, $parent, $child, $childId);
+        $this->addChildToParent($parent, $child);
+        $this->enrichGroupedExportChild($collection, $parent, $parentId, $childId);
+    }
+
+    /**
+     * @param Collection|StockCollection|PriceCollection $collection
+     * @param int $childId
+     * @param ChildOptions|null $childOptions
+     */
+    private function getOrCreateChildEntity(
+        Collection|StockCollection|PriceCollection $collection,
+        int $childId,
+        ?ChildOptions $childOptions = null
+    ): ExportEntityChild {
         if (!$this->childEntities->has($childId)) {
             $child = $this->entityChildFactory->createChild(
                 [
@@ -327,40 +345,75 @@ class Children implements DecoratorInterface
             $child->setChildOptions($childOptions);
         }
 
-        $parent = $collection->get($parentId);
+        return $child;
+    }
 
-        if (!$collection->has($childId) && $parent instanceof ExportEntityConfigurable && $child->shouldExport()) {
-            $collection->add($child);
+    /**
+     * @param Collection|StockCollection|PriceCollection $collection
+     */
+    private function addConfigurableChildToCollection(
+        Collection|StockCollection|PriceCollection $collection,
+        ExportEntity $parent,
+        ExportEntityChild $child,
+        int $childId
+    ): void {
+        if ($collection->has($childId)) {
+            return;
         }
 
-        if ($parent instanceof CompositeExportEntityInterface) {
-            $parent->addChild($child);
+        if (!$parent instanceof ExportEntityConfigurable || !$child->shouldExport()) {
+            return;
         }
 
-        if ($this->config->isGroupedExport($collection->getStore()) && $parent instanceof ExportEntityConfigurable) {
-            $childEntity = $collection->get($childId);
+        $collection->add($child);
+    }
 
-            // @phpstan-ignore-next-line
-            $childEntity->setGroupCode($parentId);
-            $childEntity->addAttribute(
-                'parent_url_key',
-                $parent->getAttribute('url_key', false)
-            );
-            $childEntity->addAttribute(
-                'parent_name',
-                $parent->getAttribute('name', false)
-            );
-            $childEntity->addAttribute(
-                'parent_visibility',
-                $parent->getAttribute('visibility', false)
-            );
+    private function addChildToParent(ExportEntity $parent, ExportEntityChild $child): void
+    {
+        if (!$parent instanceof CompositeExportEntityInterface) {
+            return;
+        }
 
-            if ($childEntity->getCategories() === []) {
-                $categories = $parent->getCategories();
-                foreach ($categories as $category) {
-                    $childEntity->addCategoryId($category);
-                }
-            }
+        $parent->addChild($child);
+    }
+
+    /**
+     * @param Collection|StockCollection|PriceCollection $collection
+     */
+    private function enrichGroupedExportChild(
+        Collection|StockCollection|PriceCollection $collection,
+        ExportEntity $parent,
+        int $parentId,
+        int $childId
+    ): void {
+        if (!$this->config->isGroupedExport($collection->getStore()) || !$parent instanceof ExportEntityConfigurable) {
+            return;
+        }
+
+        $childEntity = $collection->get($childId);
+
+        // @phpstan-ignore-next-line
+        $childEntity->setGroupCode($parentId);
+        $childEntity->addAttribute(
+            'parent_url_key',
+            $parent->getAttribute('url_key', false)
+        );
+        $childEntity->addAttribute(
+            'parent_name',
+            $parent->getAttribute('name', false)
+        );
+        $childEntity->addAttribute(
+            'parent_visibility',
+            $parent->getAttribute('visibility', false)
+        );
+
+        if ($childEntity->getCategories() !== []) {
+            return;
+        }
+
+        $categories = $parent->getCategories();
+        foreach ($categories as $category) {
+            $childEntity->addCategoryId($category);
         }
     }
 

--- a/Model/Write/Products/CollectionDecorator/Children.php
+++ b/Model/Write/Products/CollectionDecorator/Children.php
@@ -10,6 +10,7 @@ use Tweakwise\Magento2TweakwiseExport\Model\Write\Products\Collection;
 use Tweakwise\Magento2TweakwiseExport\Model\Write\Products\CollectionFactory;
 use Tweakwise\Magento2TweakwiseExport\Model\Write\Products\CompositeExportEntityInterface;
 use Tweakwise\Magento2TweakwiseExport\Model\Write\Products\ExportEntityChild;
+use Tweakwise\Magento2TweakwiseExport\Model\Write\Products\ExportEntityConfigurable;
 use Tweakwise\Magento2TweakwiseExport\Model\Write\Products\ExportEntityFactory;
 use Tweakwise\Magento2TweakwiseExport\Model\Write\Products\IteratorInitializer;
 use Magento\Bundle\Model\Product\Type as Bundle;
@@ -326,38 +327,40 @@ class Children implements DecoratorInterface
             $child->setChildOptions($childOptions);
         }
 
-        try {
-            $parent = $collection->get($parentId);
-            if ($parent instanceof CompositeExportEntityInterface) {
-                $parent->addChild($child);
-            }
+        $parent = $collection->get($parentId);
 
-            if ($this->config->isGroupedExport($collection->getStore())) {
-                $childEntity = $collection->get($childId);
-                // @phpstan-ignore-next-line
-                $childEntity->setGroupCode($parentId);
-                $childEntity->addAttribute(
-                    'parent_url_key',
-                    $parent->getAttribute('url_key', false)
-                );
-                $childEntity->addAttribute(
-                    'parent_name',
-                    $parent->getAttribute('name', false)
-                );
-                $childEntity->addAttribute(
-                    'parent_visibility',
-                    $parent->getAttribute('visibility', false)
-                );
+        if (!$collection->has($childId) && $parent instanceof ExportEntityConfigurable && $child->shouldExport()) {
+            $collection->add($child);
+        }
 
-                if ($childEntity->getCategories() === []) {
-                    $categories = $parent->getCategories();
-                    foreach ($categories as $category) {
-                        $childEntity->addCategoryId($category);
-                    }
+        if ($parent instanceof CompositeExportEntityInterface) {
+            $parent->addChild($child);
+        }
+
+        if ($this->config->isGroupedExport($collection->getStore()) && $parent instanceof ExportEntityConfigurable) {
+            $childEntity = $collection->get($childId);
+
+            // @phpstan-ignore-next-line
+            $childEntity->setGroupCode($parentId);
+            $childEntity->addAttribute(
+                'parent_url_key',
+                $parent->getAttribute('url_key', false)
+            );
+            $childEntity->addAttribute(
+                'parent_name',
+                $parent->getAttribute('name', false)
+            );
+            $childEntity->addAttribute(
+                'parent_visibility',
+                $parent->getAttribute('visibility', false)
+            );
+
+            if ($childEntity->getCategories() === []) {
+                $categories = $parent->getCategories();
+                foreach ($categories as $category) {
+                    $childEntity->addCategoryId($category);
                 }
             }
-        } catch (InvalidArgumentException $exception) {
-            // no implementation, parent was not found
         }
     }
 

--- a/Model/Write/Products/ExportEntity.php
+++ b/Model/Write/Products/ExportEntity.php
@@ -487,7 +487,7 @@ class ExportEntity
             if ($this->getTypeId() === Type::TYPE_SIMPLE) {
                 try {
                     $this->getAttribute('parent_id');
-                    return true;
+                    return false;
                 } catch (InvalidArgumentException $e) {
                     return in_array($this->getVisibility(), $this->visibilityObject->getVisibleInSiteIds(), true);
                 }


### PR DESCRIPTION
Fixes #126 

## Description
Fixed an issue where grouped export information was missing or incorrect when a batch boundary split a parent product from its children. 

## Testing Steps
Run an export for every combination of the following settings:
* Batch size and children batch size: 1 and 5000
* Grouped export: Enabled and Disabled

## Expected Results

### General Validation (Grouped & Non-Grouped)
* Product count in Tweakwise is identical regardless of batch size (1 vs 5000).
* Product information remains the same across all product types: Simple, Configurable, Bundle, and Grouped regardless of batch size (1 vs 5000).

### Grouped Export
* Verify the `groupcode` is correct for all product types.
* Verify children of configurable products contain:
    * **parent_url**
    * **parent_name**
    * **parent_visibility**: Must include both the simple product's visibility (usually 1) and the parent's visibility (usually 4).

### Non-Grouped Export
* Verify that Configurable, Bundle, and Grouped products contain data for all associated children (e.g., all available sizes are present).
