### PR TITLE
Fix: add parent product to id

### DIFF
--- a/Model/Helper.php
+++ b/Model/Helper.php
@@ -83,7 +83,7 @@ class Helper
 
     /**
      * @param string $tweakwiseId
-     * @param string|int $groupCode
+     * @param int|null $groupCode
      * @return string
      */
     private function appendGroupCodeToTweakwiseId(string $tweakwiseId, ?int $groupCode): string

--- a/Model/Helper.php
+++ b/Model/Helper.php
@@ -83,12 +83,12 @@ class Helper
 
     /**
      * @param string $tweakwiseId
-     * @param string|null $groupCode
+     * @param string|int $groupCode
      * @return string
      */
     private function appendGroupCodeToTweakwiseId(string $tweakwiseId, ?int $groupCode): string
     {
-        if ($groupCode === null || $groupCode === '') {
+        if ($groupCode === null || $groupCode === 0) {
             return $tweakwiseId;
         }
 

--- a/Model/Helper.php
+++ b/Model/Helper.php
@@ -20,6 +20,8 @@ use Magento\Framework\Stdlib\DateTime\TimezoneInterface;
 
 class Helper
 {
+    public const GROUP_CODE_DELIMITER = '-';
+
     /**
      * @var ProductMetadataInterface
      */
@@ -60,20 +62,37 @@ class Helper
         $this->config = $config;
         $this->localDate = $localDate;
     }
-
     /**
      * @param int $storeId
      * @param int $entityId
+     * @param int|null $groupCode
      * @return string
      */
-    public function getTweakwiseId(int $storeId, int $entityId): string
+    public function getTweakwiseId(int $storeId, int $entityId, ?int $groupCode = null): string
     {
+        $tweakwiseId = (string)$entityId;
         if (!$storeId) {
-            return (string)$entityId;
+            return $tweakwiseId;
         }
 
         // Prefix 1 is to make sure it stays the same length when casting to int
-        return '1' . str_pad((string)$storeId, 4, '0', STR_PAD_LEFT) . $entityId;
+        $tweakwiseId = '1' . str_pad((string)$storeId, 4, '0', STR_PAD_LEFT) . $entityId;
+
+        return $this->appendGroupCodeToTweakwiseId($tweakwiseId, $groupCode);
+    }
+
+    /**
+     * @param string $tweakwiseId
+     * @param string|null $groupCode
+     * @return string
+     */
+    private function appendGroupCodeToTweakwiseId(string $tweakwiseId, ?int $groupCode): string
+    {
+        if ($groupCode === null || $groupCode === '') {
+            return $tweakwiseId;
+        }
+
+        return $tweakwiseId . self::GROUP_CODE_DELIMITER . $groupCode;
     }
 
     /**

--- a/Model/Write/Products.php
+++ b/Model/Write/Products.php
@@ -159,7 +159,7 @@ class Products implements WriterInterface
         $xml->startElement('item');
 
         // Write product base data
-        $tweakwiseId = $this->helper->getTweakwiseId($storeId, $data['entity_id']);
+        $tweakwiseId = $this->helper->getTweakwiseId($storeId, $data['entity_id'], $this->config->isGroupedExport($this->storeManager->getStore($storeId)) ? $data['groupcode'] : null);
         $xml->writeElement('id', $tweakwiseId);
         $xml->writeElement('name', $this->scalarValue($data['name']));
         $xml->writeElement('price', $this->scalarValue((float)$data['price']));


### PR DESCRIPTION
## Description
This PR addresses an issue in the **Grouped Export** where simple products linked to multiple parent products (e.g., two or more configurables) caused the Tweakwise import to fail due to duplicate IDs.

### Changes
To ensure unique identifiers, the logic for generating item IDs in the grouped export has been updated:
* **With Configurable Parent:** The ID is now formatted as `{simple_id}-{parent_id}`.
* **Without Configurable Parent:** The ID defaults to `{simple_id}-{simple_id}`.

> [!CAUTION]
> **Breaking Change**
> This modification breaks compatibility with events in the **Magento 2 Tweakwise** module. If you utilize the grouped export alongside these events, you **must** update the Magento 2 Tweakwise module accordingly.

---

## How to Test
Verify the fix using a mix of **Configurable**, **Bundle**, **Grouped**, and **Individually Visible Simple** products.

### 1. Non-Grouped Export (Regression Testing)
Perform an export and publish. Verify that products are correctly displayed on the following pages:
- [ ] Lister Page
- [ ] Recommendations
- [ ] Suggestions
- [ ] Search
- [ ] ALP

### 2. Grouped Export (Fix Verification)
1.  Assign a single **Simple Product** to two different **Configurable Products**.
2.  Run the export.
3.  **Verify:** Ensure the Tweakwise import completes successfully without duplicate ID errors.
4.  Publish and verify product visibility on:
    - [ ] Lister Page
    - [ ] Recommendations
    - [ ] Suggestions
    - [ ] Search
    - [ ] ALP